### PR TITLE
feat: per-turn message splitting to prevent final card overwriting

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -651,6 +651,7 @@ export class MessageBridge {
 
     let messageId: string = initialCardId;
     let turnBuffer = '';
+    let turnCount = 0;
 
     const apiContext = { botName: this.config.name, chatId };
 
@@ -738,8 +739,8 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer)) {
-                  messageId = await this.recreateCard(chatId, messageId, state);
+                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
+                  messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
                   turnBuffer = '';
                 }
               }
@@ -934,8 +935,8 @@ export class MessageBridge {
             turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
             if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
-              if (await this.sendTurnText(chatId, turnBuffer)) {
-                messageId = await this.recreateCard(chatId, messageId, state);
+              if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
+                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
                 turnBuffer = '';
               }
             }
@@ -950,7 +951,7 @@ export class MessageBridge {
 
       // Flush remaining turn buffer before final card (no recreate — final card updates in place)
       if (turnBuffer && chatId) {
-        if (await this.sendTurnText(chatId, turnBuffer)) {
+        if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
           turnBuffer = '';
         }
       }
@@ -1014,8 +1015,8 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer)) {
-                  messageId = await this.recreateCard(chatId, messageId, state);
+                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
+                  messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
                   turnBuffer = '';
                 }
               }
@@ -1027,7 +1028,7 @@ export class MessageBridge {
           }
           await rateLimiter.cancelAndWait();
           if (turnBuffer && chatId) {
-            if (await this.sendTurnText(chatId, turnBuffer)) {
+            if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
               turnBuffer = '';
             }
           }
@@ -1082,7 +1083,7 @@ export class MessageBridge {
       };
       await rateLimiter.cancelAndWait();
       if (turnBuffer && chatId) {
-        if (await this.sendTurnText(chatId, turnBuffer)) {
+        if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
           turnBuffer = '';
         }
       }
@@ -1172,6 +1173,7 @@ export class MessageBridge {
 
     let messageId: string | undefined;
     let turnBuffer = '';
+    let turnCount = 0;
     if (sendCards) {
       messageId = await this.sender.sendCard(chatId, initialState);
     }
@@ -1260,9 +1262,9 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer)) {
+                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
                   if (messageId) {
-                    messageId = await this.recreateCard(chatId, messageId, state);
+                    messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
                   }
                   turnBuffer = '';
                 }
@@ -1411,9 +1413,9 @@ export class MessageBridge {
             turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
             if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
-              if (await this.sendTurnText(chatId, turnBuffer)) {
+              if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
                 if (messageId) {
-                  messageId = await this.recreateCard(chatId, messageId, state);
+                  messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
                 }
                 turnBuffer = '';
               }
@@ -1431,7 +1433,7 @@ export class MessageBridge {
       }
 
       if (turnBuffer && chatId && messageId) {
-        if (await this.sendTurnText(chatId, turnBuffer)) {
+        if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
           turnBuffer = '';
         }
       }
@@ -1503,9 +1505,9 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer)) {
+                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
                   if (messageId) {
-                    messageId = await this.recreateCard(chatId, messageId, state);
+                    messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
                   }
                   turnBuffer = '';
                 }
@@ -1522,7 +1524,7 @@ export class MessageBridge {
           await rateLimiter.cancelAndWait();
 
           if (turnBuffer && chatId && messageId) {
-            if (await this.sendTurnText(chatId, turnBuffer)) {
+            if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
               turnBuffer = '';
             }
           }
@@ -1562,7 +1564,7 @@ export class MessageBridge {
         };
         await rateLimiter.cancelAndWait();
         if (turnBuffer && chatId && messageId) {
-          if (await this.sendTurnText(chatId, turnBuffer)) {
+          if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
             turnBuffer = '';
           }
         }
@@ -1606,7 +1608,7 @@ export class MessageBridge {
    */
   private async sendFinalCard(messageId: string, state: CardState, chatId?: string, unsentText?: string): Promise<void> {
     // If there's unsent turn text (💬 failed), fall back to showing it in the card
-    const cardState = { ...state, responseText: unsentText || '' };
+    const cardState = { ...state, responseText: unsentText || '', cardTitle: '📊 Result' };
 
     let updateSucceeded = false;
     for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
@@ -1639,7 +1641,7 @@ export class MessageBridge {
 
     // Send result summary as a separate message (with splitting for long results)
     if (state.resultSummary && chatId) {
-      await this.sendTurnText(chatId, state.resultSummary);
+      await this.sendTurnText(chatId, state.resultSummary, '📊 Result');
     }
   }
 
@@ -1648,15 +1650,16 @@ export class MessageBridge {
    * Splits long text using the same logic as continuation cards.
    * Returns true if at least the first chunk was sent successfully.
    */
-  private async sendTurnText(chatId: string, text: string): Promise<boolean> {
+  private async sendTurnText(chatId: string, text: string, turnLabel?: string): Promise<boolean> {
     const chunks = splitResponseText(text);
     const total = chunks.length;
     let sentAny = false;
+    const prefix = turnLabel || '💬';
 
     for (let i = 0; i < total; i++) {
       try {
         if (i > 0) await new Promise((r) => setTimeout(r, 1500));
-        const title = total > 1 ? `💬 (${i + 1}/${total})` : '💬';
+        const title = total > 1 ? `${prefix} (${i + 1}/${total})` : prefix;
         await this.sender.sendTextNotice(chatId, title, chunks[i], 'blue');
         sentAny = true;
       } catch (err) {
@@ -1670,10 +1673,10 @@ export class MessageBridge {
    * Freeze old card and create a new one at the bottom so the card stays below 💬 messages.
    * Returns the new messageId, or the old one if card creation failed.
    */
-  private async recreateCard(chatId: string, oldMessageId: string, state: CardState): Promise<string> {
-    // Freeze old card: mark complete, clear response text (already sent as 💬)
+  private async recreateCard(chatId: string, oldMessageId: string, state: CardState, turnLabel?: string): Promise<string> {
+    // Freeze old card: mark complete with turn label, clear response text (already sent as 💬)
     try {
-      await this.sender.updateCard(oldMessageId, { ...state, status: 'complete', responseText: '' });
+      await this.sender.updateCard(oldMessageId, { ...state, status: 'complete', responseText: '', cardTitle: turnLabel });
     } catch { /* best effort */ }
     // Create new card at bottom for next turn
     try {

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -729,6 +729,12 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
 
+            // Per-turn message: send completed turn text as a separate message
+            if (state.completedTurnText && chatId) {
+              await rateLimiter.flush();
+              await this.sendTurnText(chatId, state.completedTurnText);
+            }
+
             // Update session ID if discovered
             const newSessionId = processor.getSessionId();
             if (newSessionId && newSessionId !== session.sessionId) {
@@ -914,6 +920,10 @@ export class MessageBridge {
           resetIdleTimer();
           const state = processor.processMessage(message);
           lastState = state;
+          if (state.completedTurnText && chatId) {
+            await rateLimiter.flush();
+            await this.sendTurnText(chatId, state.completedTurnText);
+          }
           const newSid = processor.getSessionId();
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
           if (state.status === 'complete' || state.status === 'error') break;
@@ -978,6 +988,10 @@ export class MessageBridge {
             resetIdleTimer();
             const state = processor.processMessage(message);
             lastState = state;
+            if (state.completedTurnText && chatId) {
+              await rateLimiter.flush();
+              await this.sendTurnText(chatId, state.completedTurnText);
+            }
             const newSid = processor.getSessionId();
             if (newSid) this.sessionManager.setSessionId(chatId, newSid);
             if (state.status === 'complete' || state.status === 'error') break;
@@ -1202,6 +1216,12 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
 
+            // Per-turn message: send completed turn text as a separate message
+            if (state.completedTurnText && chatId) {
+              await rateLimiter.flush();
+              await this.sendTurnText(chatId, state.completedTurnText);
+            }
+
             const newSessionId = processor.getSessionId();
             if (newSessionId && newSessionId !== session.sessionId) {
               this.sessionManager.setSessionId(chatId, newSessionId);
@@ -1340,6 +1360,10 @@ export class MessageBridge {
           resetIdleTimer();
           const state = processor.processMessage(message);
           lastState = state;
+          if (state.completedTurnText && chatId) {
+            await rateLimiter.flush();
+            await this.sendTurnText(chatId, state.completedTurnText);
+          }
           const newSid = processor.getSessionId();
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
           if (state.status === 'complete' || state.status === 'error') break;
@@ -1415,6 +1439,10 @@ export class MessageBridge {
             resetIdleTimer();
             const state = processor.processMessage(message);
             lastState = state;
+            if (state.completedTurnText && chatId) {
+              await rateLimiter.flush();
+              await this.sendTurnText(chatId, state.completedTurnText);
+            }
             const newSid = processor.getSessionId();
             if (newSid) this.sessionManager.setSessionId(chatId, newSid);
             if (state.status === 'complete' || state.status === 'error') break;
@@ -1499,13 +1527,8 @@ export class MessageBridge {
    * sends a plain text fallback so the user at least sees the result.
    */
   private async sendFinalCard(messageId: string, state: CardState, chatId?: string): Promise<void> {
-    // Split long responses into multiple cards
-    const chunks = state.responseText ? splitResponseText(state.responseText) : null;
-    const needsSplit = chunks !== null && chunks.length > 1;
-
-    const cardState = needsSplit
-      ? { ...state, responseText: chunks[0] + `\n\n---\n_📄 (1/${chunks.length})_` }
-      : state;
+    // Main card: status-only (response text was sent per-turn, result goes as separate message)
+    const cardState = { ...state, responseText: '' };
 
     let updateSucceeded = false;
     for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
@@ -1528,9 +1551,7 @@ export class MessageBridge {
       if (chatId) {
         this.logger.error({ messageId, chatId }, 'All final card retries failed, sending text fallback');
         const statusEmoji = state.status === 'complete' ? '✅' : '❌';
-        const summary = state.responseText
-          ? state.responseText.slice(0, 2000)
-          : state.errorMessage || 'Task finished';
+        const summary = (state.resultSummary || state.responseText || state.errorMessage || 'Task finished').slice(0, 2000);
         try {
           await this.sender.sendText(chatId, `${statusEmoji} ${summary}`);
         } catch { /* last resort failed */ }
@@ -1538,21 +1559,27 @@ export class MessageBridge {
       return;
     }
 
-    // Send continuation cards for remaining chunks
-    if (needsSplit && chatId) {
-      this.logger.info({ chatId, totalChunks: chunks.length }, 'Sending continuation cards for long response');
-      for (let i = 1; i < chunks.length; i++) {
-        try {
-          await new Promise((r) => setTimeout(r, 1500));
-          await this.sender.sendTextNotice(
-            chatId,
-            `📄 Continued (${i + 1}/${chunks.length})`,
-            chunks[i] + `\n\n---\n_📄 (${i + 1}/${chunks.length})_`,
-            'green',
-          );
-        } catch {
-          this.logger.warn({ chatId, chunk: i + 1, total: chunks.length }, 'Failed to send continuation card');
-        }
+    // Send result summary as a separate message (with splitting for long results)
+    if (state.resultSummary && chatId) {
+      await this.sendTurnText(chatId, state.resultSummary);
+    }
+  }
+
+  /**
+   * Send completed turn text as one or more separate text messages.
+   * Splits long text using the same logic as continuation cards.
+   */
+  private async sendTurnText(chatId: string, text: string): Promise<void> {
+    const chunks = splitResponseText(text);
+    const total = chunks.length;
+
+    for (let i = 0; i < total; i++) {
+      try {
+        if (i > 0) await new Promise((r) => setTimeout(r, 1500));
+        const title = total > 1 ? `💬 (${i + 1}/${total})` : '💬';
+        await this.sender.sendTextNotice(chatId, title, chunks[i], 'blue');
+      } catch (err) {
+        this.logger.warn({ err, chatId, chunk: i + 1, total }, 'Failed to send turn text');
       }
     }
   }

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -738,9 +738,10 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                await this.sendTurnText(chatId, turnBuffer);
-                messageId = await this.recreateCard(chatId, messageId, state);
-                turnBuffer = '';
+                if (await this.sendTurnText(chatId, turnBuffer)) {
+                  messageId = await this.recreateCard(chatId, messageId, state);
+                  turnBuffer = '';
+                }
               }
             }
 
@@ -933,9 +934,10 @@ export class MessageBridge {
             turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
             if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
-              await this.sendTurnText(chatId, turnBuffer);
-              messageId = await this.recreateCard(chatId, messageId, state);
-              turnBuffer = '';
+              if (await this.sendTurnText(chatId, turnBuffer)) {
+                messageId = await this.recreateCard(chatId, messageId, state);
+                turnBuffer = '';
+              }
             }
           }
           const newSid = processor.getSessionId();
@@ -948,11 +950,12 @@ export class MessageBridge {
 
       // Flush remaining turn buffer before final card
       if (turnBuffer && chatId) {
-        await this.sendTurnText(chatId, turnBuffer);
-        messageId = await this.recreateCard(chatId, messageId, lastState);
-        turnBuffer = '';
+        if (await this.sendTurnText(chatId, turnBuffer)) {
+          messageId = await this.recreateCard(chatId, messageId, lastState);
+          turnBuffer = '';
+        }
       }
-      await this.sendFinalCard(messageId, lastState, chatId);
+      await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
 
       // Audit + cost tracking
       const durationMs = Date.now() - startTime;
@@ -1012,9 +1015,10 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                await this.sendTurnText(chatId, turnBuffer);
-                messageId = await this.recreateCard(chatId, messageId, state);
-                turnBuffer = '';
+                if (await this.sendTurnText(chatId, turnBuffer)) {
+                  messageId = await this.recreateCard(chatId, messageId, state);
+                  turnBuffer = '';
+                }
               }
             }
             const newSid = processor.getSessionId();
@@ -1024,11 +1028,12 @@ export class MessageBridge {
           }
           await rateLimiter.cancelAndWait();
           if (turnBuffer && chatId) {
-            await this.sendTurnText(chatId, turnBuffer);
-            messageId = await this.recreateCard(chatId, messageId, lastState);
-            turnBuffer = '';
+            if (await this.sendTurnText(chatId, turnBuffer)) {
+              messageId = await this.recreateCard(chatId, messageId, lastState);
+              turnBuffer = '';
+            }
           }
-          await this.sendFinalCard(messageId, lastState, chatId);
+          await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
 
           const durationMs = Date.now() - startTime;
           this.audit.log({
@@ -1079,11 +1084,12 @@ export class MessageBridge {
       };
       await rateLimiter.cancelAndWait();
       if (turnBuffer && chatId) {
-        await this.sendTurnText(chatId, turnBuffer);
-        messageId = await this.recreateCard(chatId, messageId, lastState);
-        turnBuffer = '';
+        if (await this.sendTurnText(chatId, turnBuffer)) {
+          messageId = await this.recreateCard(chatId, messageId, lastState);
+          turnBuffer = '';
+        }
       }
-      await this.sendFinalCard(messageId, errorState, chatId);
+      await this.sendFinalCard(messageId, errorState, chatId, turnBuffer || undefined);
     } finally {
       clearInterval(thinkingTimerId);
       clearTimeout(timeoutId);
@@ -1257,11 +1263,12 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                await this.sendTurnText(chatId, turnBuffer);
-                if (messageId) {
-                  messageId = await this.recreateCard(chatId, messageId, state);
+                if (await this.sendTurnText(chatId, turnBuffer)) {
+                  if (messageId) {
+                    messageId = await this.recreateCard(chatId, messageId, state);
+                  }
+                  turnBuffer = '';
                 }
-                turnBuffer = '';
               }
             }
 
@@ -1407,11 +1414,12 @@ export class MessageBridge {
             turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
             if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
-              await this.sendTurnText(chatId, turnBuffer);
-              if (messageId) {
-                messageId = await this.recreateCard(chatId, messageId, state);
+              if (await this.sendTurnText(chatId, turnBuffer)) {
+                if (messageId) {
+                  messageId = await this.recreateCard(chatId, messageId, state);
+                }
+                turnBuffer = '';
               }
-              turnBuffer = '';
             }
           }
           const newSid = processor.getSessionId();
@@ -1426,12 +1434,13 @@ export class MessageBridge {
       }
 
       if (turnBuffer && chatId && messageId) {
-        await this.sendTurnText(chatId, turnBuffer);
-        messageId = await this.recreateCard(chatId, messageId, lastState);
-        turnBuffer = '';
+        if (await this.sendTurnText(chatId, turnBuffer)) {
+          messageId = await this.recreateCard(chatId, messageId, lastState);
+          turnBuffer = '';
+        }
       }
       if (sendCards && messageId) {
-        await this.sendFinalCard(messageId, lastState, chatId);
+        await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
       }
       options.onUpdate?.(lastState, effectiveMessageId, true);
 
@@ -1498,11 +1507,12 @@ export class MessageBridge {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                await this.sendTurnText(chatId, turnBuffer);
-                if (messageId) {
-                  messageId = await this.recreateCard(chatId, messageId, state);
+                if (await this.sendTurnText(chatId, turnBuffer)) {
+                  if (messageId) {
+                    messageId = await this.recreateCard(chatId, messageId, state);
+                  }
+                  turnBuffer = '';
                 }
-                turnBuffer = '';
               }
             }
             const newSid = processor.getSessionId();
@@ -1516,12 +1526,13 @@ export class MessageBridge {
           await rateLimiter.cancelAndWait();
 
           if (turnBuffer && chatId && messageId) {
-            await this.sendTurnText(chatId, turnBuffer);
-            messageId = await this.recreateCard(chatId, messageId, lastState);
-            turnBuffer = '';
+            if (await this.sendTurnText(chatId, turnBuffer)) {
+              messageId = await this.recreateCard(chatId, messageId, lastState);
+              turnBuffer = '';
+            }
           }
           if (sendCards && messageId) {
-            await this.sendFinalCard(messageId, lastState, chatId);
+            await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
           }
           options.onUpdate?.(lastState, effectiveMessageId, true);
 
@@ -1556,11 +1567,12 @@ export class MessageBridge {
         };
         await rateLimiter.cancelAndWait();
         if (turnBuffer && chatId && messageId) {
-          await this.sendTurnText(chatId, turnBuffer);
-          messageId = await this.recreateCard(chatId, messageId, lastState);
-          turnBuffer = '';
+          if (await this.sendTurnText(chatId, turnBuffer)) {
+            messageId = await this.recreateCard(chatId, messageId, lastState);
+            turnBuffer = '';
+          }
         }
-        await this.sendFinalCard(messageId, errorState, chatId);
+        await this.sendFinalCard(messageId, errorState, chatId, turnBuffer || undefined);
       }
 
       const catchErrorState: CardState = {
@@ -1598,9 +1610,9 @@ export class MessageBridge {
    * Retries with exponential backoff (2s → 4s → 8s). If all retries fail,
    * sends a plain text fallback so the user at least sees the result.
    */
-  private async sendFinalCard(messageId: string, state: CardState, chatId?: string): Promise<void> {
-    // Main card: status-only (response text was sent per-turn, result goes as separate message)
-    const cardState = { ...state, responseText: '' };
+  private async sendFinalCard(messageId: string, state: CardState, chatId?: string, unsentText?: string): Promise<void> {
+    // If there's unsent turn text (💬 failed), fall back to showing it in the card
+    const cardState = { ...state, responseText: unsentText || '' };
 
     let updateSucceeded = false;
     for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
@@ -1640,20 +1652,24 @@ export class MessageBridge {
   /**
    * Send completed turn text as one or more separate text messages.
    * Splits long text using the same logic as continuation cards.
+   * Returns true if at least the first chunk was sent successfully.
    */
-  private async sendTurnText(chatId: string, text: string): Promise<void> {
+  private async sendTurnText(chatId: string, text: string): Promise<boolean> {
     const chunks = splitResponseText(text);
     const total = chunks.length;
+    let sentAny = false;
 
     for (let i = 0; i < total; i++) {
       try {
         if (i > 0) await new Promise((r) => setTimeout(r, 1500));
         const title = total > 1 ? `💬 (${i + 1}/${total})` : '💬';
         await this.sender.sendTextNotice(chatId, title, chunks[i], 'blue');
+        sentAny = true;
       } catch (err) {
         this.logger.warn({ err, chatId, chunk: i + 1, total }, 'Failed to send turn text');
       }
     }
+    return sentAny;
   }
 
   /**
@@ -1661,9 +1677,9 @@ export class MessageBridge {
    * Returns the new messageId, or the old one if card creation failed.
    */
   private async recreateCard(chatId: string, oldMessageId: string, state: CardState): Promise<string> {
-    // Freeze old card: clear response text (already sent as 💬)
+    // Freeze old card: mark complete, clear response text (already sent as 💬)
     try {
-      await this.sender.updateCard(oldMessageId, { ...state, responseText: '' });
+      await this.sender.updateCard(oldMessageId, { ...state, status: 'complete', responseText: '' });
     } catch { /* best effort */ }
     // Create new card at bottom for next turn
     try {

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -738,12 +738,10 @@ export class MessageBridge {
             // Per-turn message: buffer short turns, send when threshold is met
             if (state.completedTurnText && chatId) {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
-              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+              if (!needsRecreate && turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  needsRecreate = true;
-                  turnBuffer = '';
-                }
+                ++turnCount;
+                needsRecreate = true;
               }
             }
 
@@ -846,8 +844,9 @@ export class MessageBridge {
             // Deferred recreate: move card to bottom when new content starts after turn flush
             if (needsRecreate && state.responseText) {
               await rateLimiter.flush();
-              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
               needsRecreate = false;
+              turnBuffer = '';
             }
 
             // Throttled card update for non-final states
@@ -941,12 +940,10 @@ export class MessageBridge {
           lastState = state;
           if (state.completedTurnText && chatId) {
             turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
-            if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+            if (!needsRecreate && turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
-              if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                needsRecreate = true;
-                turnBuffer = '';
-              }
+              ++turnCount;
+              needsRecreate = true;
             }
           }
           const newSid = processor.getSessionId();
@@ -954,8 +951,9 @@ export class MessageBridge {
           if (state.status === 'complete' || state.status === 'error') break;
           if (needsRecreate && state.responseText) {
             await rateLimiter.flush();
-            messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+            messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
             needsRecreate = false;
+            turnBuffer = '';
           }
           rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
         }
@@ -963,12 +961,8 @@ export class MessageBridge {
       }
 
       // Flush remaining turn buffer before final card (no recreate — final card updates in place)
-      if (turnBuffer && chatId) {
-        if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-          turnBuffer = '';
-        }
-      }
-      await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
+      if (turnBuffer && !needsRecreate) ++turnCount;
+      await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined, turnCount);
 
       // Audit + cost tracking
       const durationMs = Date.now() - startTime;
@@ -1026,12 +1020,10 @@ export class MessageBridge {
             lastState = state;
             if (state.completedTurnText && chatId) {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
-              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+              if (!needsRecreate && turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  needsRecreate = true;
-                  turnBuffer = '';
-                }
+                ++turnCount;
+                needsRecreate = true;
               }
             }
             const newSid = processor.getSessionId();
@@ -1039,18 +1031,15 @@ export class MessageBridge {
             if (state.status === 'complete' || state.status === 'error') break;
             if (needsRecreate && state.responseText) {
               await rateLimiter.flush();
-              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
               needsRecreate = false;
+              turnBuffer = '';
             }
             rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
           }
           await rateLimiter.cancelAndWait();
-          if (turnBuffer && chatId) {
-            if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-              turnBuffer = '';
-            }
-          }
-          await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
+          if (turnBuffer && !needsRecreate) ++turnCount;
+          await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined, turnCount);
 
           const durationMs = Date.now() - startTime;
           this.audit.log({
@@ -1100,12 +1089,8 @@ export class MessageBridge {
         errorMessage: err.message || 'Unknown error',
       };
       await rateLimiter.cancelAndWait();
-      if (turnBuffer && chatId) {
-        if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-          turnBuffer = '';
-        }
-      }
-      await this.sendFinalCard(messageId, errorState, chatId, turnBuffer || undefined);
+      if (turnBuffer && !needsRecreate) ++turnCount;
+      await this.sendFinalCard(messageId, errorState, chatId, turnBuffer || undefined, turnCount);
     } finally {
       clearInterval(thinkingTimerId);
       clearTimeout(timeoutId);
@@ -1279,12 +1264,10 @@ export class MessageBridge {
             // Per-turn message: buffer short turns, send when threshold is met
             if (state.completedTurnText && chatId) {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
-              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+              if (!needsRecreate && turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  needsRecreate = true;
-                  turnBuffer = '';
-                }
+                ++turnCount;
+                needsRecreate = true;
               }
             }
 
@@ -1342,8 +1325,9 @@ export class MessageBridge {
             if (sendCards && messageId) {
               if (needsRecreate && state.responseText) {
                 await rateLimiter.flush();
-                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
                 needsRecreate = false;
+                turnBuffer = '';
               }
               rateLimiter.schedule(() => {
                 this.sender.updateCard(messageId!, state).catch(() => {});
@@ -1433,12 +1417,10 @@ export class MessageBridge {
           lastState = state;
           if (state.completedTurnText && chatId) {
             turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
-            if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+            if (!needsRecreate && turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
-              if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                needsRecreate = true;
-                turnBuffer = '';
-              }
+              ++turnCount;
+              needsRecreate = true;
             }
           }
           const newSid = processor.getSessionId();
@@ -1447,8 +1429,9 @@ export class MessageBridge {
           if (sendCards && messageId) {
             if (needsRecreate && state.responseText) {
               await rateLimiter.flush();
-              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
               needsRecreate = false;
+              turnBuffer = '';
             }
             rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
           }
@@ -1457,13 +1440,9 @@ export class MessageBridge {
         await rateLimiter.cancelAndWait();
       }
 
-      if (turnBuffer && chatId && messageId) {
-        if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-          turnBuffer = '';
-        }
-      }
+      if (turnBuffer && !needsRecreate) ++turnCount;
       if (sendCards && messageId) {
-        await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
+        await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined, turnCount);
       }
       options.onUpdate?.(lastState, effectiveMessageId, true);
 
@@ -1528,12 +1507,10 @@ export class MessageBridge {
             lastState = state;
             if (state.completedTurnText && chatId) {
               turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
-              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+              if (!needsRecreate && turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
-                if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  needsRecreate = true;
-                  turnBuffer = '';
-                }
+                ++turnCount;
+                needsRecreate = true;
               }
             }
             const newSid = processor.getSessionId();
@@ -1542,8 +1519,9 @@ export class MessageBridge {
             if (sendCards && messageId) {
               if (needsRecreate && state.responseText) {
                 await rateLimiter.flush();
-                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
                 needsRecreate = false;
+                turnBuffer = '';
               }
               rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
             }
@@ -1551,13 +1529,9 @@ export class MessageBridge {
           }
           await rateLimiter.cancelAndWait();
 
-          if (turnBuffer && chatId && messageId) {
-            if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-              turnBuffer = '';
-            }
-          }
+          if (turnBuffer && !needsRecreate) ++turnCount;
           if (sendCards && messageId) {
-            await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined);
+            await this.sendFinalCard(messageId, lastState, chatId, turnBuffer || undefined, turnCount);
           }
           options.onUpdate?.(lastState, effectiveMessageId, true);
 
@@ -1591,12 +1565,8 @@ export class MessageBridge {
           errorMessage: err.message || 'Unknown error',
         };
         await rateLimiter.cancelAndWait();
-        if (turnBuffer && chatId && messageId) {
-          if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-            turnBuffer = '';
-          }
-        }
-        await this.sendFinalCard(messageId, errorState, chatId, turnBuffer || undefined);
+        if (turnBuffer && !needsRecreate) ++turnCount;
+        await this.sendFinalCard(messageId, errorState, chatId, turnBuffer || undefined, turnCount);
       }
 
       const catchErrorState: CardState = {
@@ -1634,44 +1604,79 @@ export class MessageBridge {
    * Retries with exponential backoff (2s → 4s → 8s). If all retries fail,
    * sends a plain text fallback so the user at least sees the result.
    */
-  private async sendFinalCard(messageId: string, state: CardState, chatId?: string, unsentText?: string): Promise<void> {
-    // If there's unsent turn text (💬 failed), fall back to showing it in the card.
-    // If no content at all, show a pointer to the 💬 messages above.
-    const displayText = unsentText || state.responseText || '_See 💬 messages above for full response_';
-    const cardState = { ...state, responseText: displayText, cardTitle: '📊 Result' };
+  private async sendFinalCard(
+    messageId: string,
+    state: CardState,
+    chatId?: string,
+    lastTurnText?: string,
+    turnCount: number = 0,
+  ): Promise<void> {
+    let succeeded = false;
 
-    let updateSucceeded = false;
-    for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
+    if (turnCount > 0 && chatId) {
+      // Multi-turn path: freeze the current card with the last turn's content,
+      // then send a brand-new Result card at the bottom so it always appears
+      // after all turn cards.
+      const freezeState = {
+        ...state,
+        status: 'complete' as const,
+        responseText: lastTurnText || '',
+        cardTitle: `Turn ${turnCount}`,
+      };
       try {
-        await this.sender.updateCard(messageId, cardState);
-        if (attempt > 0) {
-          await new Promise((r) => setTimeout(r, FINAL_CARD_BASE_DELAY_MS));
-          await this.sender.updateCard(messageId, cardState);
-        }
-        updateSucceeded = true;
-        break;
+        await this.sender.updateCard(messageId, freezeState);
       } catch {
-        const delay = FINAL_CARD_BASE_DELAY_MS * Math.pow(2, attempt);
-        this.logger.warn({ attempt, delay, messageId }, 'Final card update failed, retrying');
-        await new Promise((r) => setTimeout(r, delay));
+        await new Promise((r) => setTimeout(r, 1000));
+        try { await this.sender.updateCard(messageId, freezeState); } catch { this.logger.warn({ messageId }, 'Freeze failed after retry — card may stay running'); }
       }
-    }
 
-    if (!updateSucceeded) {
-      if (chatId) {
-        this.logger.error({ messageId, chatId }, 'All final card retries failed, sending text fallback');
-        const statusEmoji = state.status === 'complete' ? '✅' : '❌';
-        const summary = (state.resultSummary || state.responseText || state.errorMessage || 'Task finished').slice(0, 2000);
+      // Result card shows the SDK summary (if any), otherwise a pointer to the turn cards.
+      const resultText = state.resultSummary || '_See cards above for full response_';
+      const resultState = { ...state, responseText: resultText, cardTitle: '📊 Result' };
+      for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
         try {
-          await this.sender.sendText(chatId, `${statusEmoji} ${summary}`);
-        } catch { /* last resort failed */ }
+          if (attempt > 0) await new Promise((r) => setTimeout(r, FINAL_CARD_BASE_DELAY_MS));
+          await this.sender.sendCard(chatId, resultState);
+          succeeded = true;
+          break;
+        } catch {
+          const delay = FINAL_CARD_BASE_DELAY_MS * Math.pow(2, attempt);
+          this.logger.warn({ attempt, delay }, 'Result card send failed, retrying');
+          await new Promise((r) => setTimeout(r, delay));
+        }
       }
-      return;
+    } else {
+      // Single-turn / no-split path: update the existing card in place.
+      const displayText = lastTurnText || state.responseText || '_See cards above for full response_';
+      const cardState = { ...state, responseText: displayText, cardTitle: '📊 Result' };
+      for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {
+        try {
+          await this.sender.updateCard(messageId, cardState);
+          if (attempt > 0) {
+            await new Promise((r) => setTimeout(r, FINAL_CARD_BASE_DELAY_MS));
+            await this.sender.updateCard(messageId, cardState);
+          }
+          succeeded = true;
+          break;
+        } catch {
+          const delay = FINAL_CARD_BASE_DELAY_MS * Math.pow(2, attempt);
+          this.logger.warn({ attempt, delay, messageId }, 'Final card update failed, retrying');
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+      if (succeeded && state.resultSummary && chatId) {
+        // For single-turn, send the SDK summary as a follow-up message.
+        await this.sendTurnText(chatId, state.resultSummary, '📊 Result');
+      }
     }
 
-    // Send result summary as a separate message (with splitting for long results)
-    if (state.resultSummary && chatId) {
-      await this.sendTurnText(chatId, state.resultSummary, '📊 Result');
+    if (!succeeded && chatId) {
+      this.logger.error({ messageId, chatId }, 'All final card retries failed, sending text fallback');
+      const statusEmoji = state.status === 'complete' ? '✅' : '❌';
+      const summary = (state.resultSummary || lastTurnText || state.responseText || state.errorMessage || 'Task finished').slice(0, 2000);
+      try {
+        await this.sender.sendText(chatId, `${statusEmoji} ${summary}`);
+      } catch { /* last resort failed */ }
     }
   }
 
@@ -1703,11 +1708,18 @@ export class MessageBridge {
    * Freeze old card and create a new one at the bottom so the card stays below 💬 messages.
    * Returns the new messageId, or the old one if card creation failed.
    */
-  private async recreateCard(chatId: string, oldMessageId: string, state: CardState, turnLabel?: string): Promise<string> {
-    // Freeze old card: mark complete with turn label, clear response text (already sent as 💬)
+  private async recreateCard(chatId: string, oldMessageId: string, state: CardState, turnLabel?: string, turnText?: string): Promise<string> {
+    // Freeze old card with the completed turn's content so the card itself shows the response.
+    const freezeState = { ...state, status: 'complete' as const, responseText: turnText || '', cardTitle: turnLabel };
     try {
-      await this.sender.updateCard(oldMessageId, { ...state, status: 'complete', responseText: '', cardTitle: turnLabel });
-    } catch { /* best effort */ }
+      await this.sender.updateCard(oldMessageId, freezeState);
+    } catch {
+      // Retry once — if the freeze fails the old card stays "running", which is a visible glitch
+      await new Promise((r) => setTimeout(r, 1000));
+      try {
+        await this.sender.updateCard(oldMessageId, freezeState);
+      } catch { this.logger.warn({ oldMessageId }, 'recreateCard freeze failed after retry'); }
+    }
     // Create new card at bottom for next turn
     try {
       const newId = await this.sender.sendCard(chatId, {

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -23,6 +23,7 @@ import type { SessionRegistry } from '../session/session-registry.js';
 const TASK_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
 const QUESTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes for user to answer
 const MAX_QUEUE_SIZE = 5; // max queued messages per chat
+const TURN_MERGE_THRESHOLD = 300; // buffer short turns until combined text reaches this length
 const IDLE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour idle → abort
 const FINAL_CARD_RETRIES = 3;
 const MAX_CONSECUTIVE_AUTO_ANSWERS = 3; // abort after this many unanswered permission prompts in a row
@@ -649,6 +650,7 @@ export class MessageBridge {
     }
 
     let messageId: string = initialCardId;
+    let turnBuffer = '';
 
     const apiContext = { botName: this.config.name, chatId };
 
@@ -731,11 +733,15 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
 
-            // Per-turn message: send completed turn text as a separate message
+            // Per-turn message: buffer short turns, send when threshold is met
             if (state.completedTurnText && chatId) {
-              await rateLimiter.flush();
-              await this.sendTurnText(chatId, state.completedTurnText);
-              messageId = await this.recreateCard(chatId, messageId, state);
+              turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
+              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+                await rateLimiter.flush();
+                await this.sendTurnText(chatId, turnBuffer);
+                messageId = await this.recreateCard(chatId, messageId, state);
+                turnBuffer = '';
+              }
             }
 
             // Update session ID if discovered
@@ -924,9 +930,13 @@ export class MessageBridge {
           const state = processor.processMessage(message);
           lastState = state;
           if (state.completedTurnText && chatId) {
-            await rateLimiter.flush();
-            await this.sendTurnText(chatId, state.completedTurnText);
-            messageId = await this.recreateCard(chatId, messageId, state);
+            turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
+            if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+              await rateLimiter.flush();
+              await this.sendTurnText(chatId, turnBuffer);
+              messageId = await this.recreateCard(chatId, messageId, state);
+              turnBuffer = '';
+            }
           }
           const newSid = processor.getSessionId();
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
@@ -936,6 +946,12 @@ export class MessageBridge {
         await rateLimiter.cancelAndWait();
       }
 
+      // Flush remaining turn buffer before final card
+      if (turnBuffer && chatId) {
+        await this.sendTurnText(chatId, turnBuffer);
+        messageId = await this.recreateCard(chatId, messageId, lastState);
+        turnBuffer = '';
+      }
       await this.sendFinalCard(messageId, lastState, chatId);
 
       // Audit + cost tracking
@@ -993,9 +1009,13 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
             if (state.completedTurnText && chatId) {
-              await rateLimiter.flush();
-              await this.sendTurnText(chatId, state.completedTurnText);
-              messageId = await this.recreateCard(chatId, messageId, state);
+              turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
+              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+                await rateLimiter.flush();
+                await this.sendTurnText(chatId, turnBuffer);
+                messageId = await this.recreateCard(chatId, messageId, state);
+                turnBuffer = '';
+              }
             }
             const newSid = processor.getSessionId();
             if (newSid) this.sessionManager.setSessionId(chatId, newSid);
@@ -1003,6 +1023,11 @@ export class MessageBridge {
             rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
           }
           await rateLimiter.cancelAndWait();
+          if (turnBuffer && chatId) {
+            await this.sendTurnText(chatId, turnBuffer);
+            messageId = await this.recreateCard(chatId, messageId, lastState);
+            turnBuffer = '';
+          }
           await this.sendFinalCard(messageId, lastState, chatId);
 
           const durationMs = Date.now() - startTime;
@@ -1053,6 +1078,11 @@ export class MessageBridge {
         errorMessage: err.message || 'Unknown error',
       };
       await rateLimiter.cancelAndWait();
+      if (turnBuffer && chatId) {
+        await this.sendTurnText(chatId, turnBuffer);
+        messageId = await this.recreateCard(chatId, messageId, lastState);
+        turnBuffer = '';
+      }
       await this.sendFinalCard(messageId, errorState, chatId);
     } finally {
       clearInterval(thinkingTimerId);
@@ -1138,6 +1168,7 @@ export class MessageBridge {
     };
 
     let messageId: string | undefined;
+    let turnBuffer = '';
     if (sendCards) {
       messageId = await this.sender.sendCard(chatId, initialState);
     }
@@ -1221,12 +1252,16 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
 
-            // Per-turn message: send completed turn text as a separate message
+            // Per-turn message: buffer short turns, send when threshold is met
             if (state.completedTurnText && chatId) {
-              await rateLimiter.flush();
-              await this.sendTurnText(chatId, state.completedTurnText);
-              if (messageId) {
-                messageId = await this.recreateCard(chatId, messageId, state);
+              turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
+              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+                await rateLimiter.flush();
+                await this.sendTurnText(chatId, turnBuffer);
+                if (messageId) {
+                  messageId = await this.recreateCard(chatId, messageId, state);
+                }
+                turnBuffer = '';
               }
             }
 
@@ -1369,10 +1404,14 @@ export class MessageBridge {
           const state = processor.processMessage(message);
           lastState = state;
           if (state.completedTurnText && chatId) {
-            await rateLimiter.flush();
-            await this.sendTurnText(chatId, state.completedTurnText);
-            if (messageId) {
-              messageId = await this.recreateCard(chatId, messageId, state);
+            turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
+            if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+              await rateLimiter.flush();
+              await this.sendTurnText(chatId, turnBuffer);
+              if (messageId) {
+                messageId = await this.recreateCard(chatId, messageId, state);
+              }
+              turnBuffer = '';
             }
           }
           const newSid = processor.getSessionId();
@@ -1386,6 +1425,11 @@ export class MessageBridge {
         await rateLimiter.cancelAndWait();
       }
 
+      if (turnBuffer && chatId && messageId) {
+        await this.sendTurnText(chatId, turnBuffer);
+        messageId = await this.recreateCard(chatId, messageId, lastState);
+        turnBuffer = '';
+      }
       if (sendCards && messageId) {
         await this.sendFinalCard(messageId, lastState, chatId);
       }
@@ -1451,10 +1495,14 @@ export class MessageBridge {
             const state = processor.processMessage(message);
             lastState = state;
             if (state.completedTurnText && chatId) {
-              await rateLimiter.flush();
-              await this.sendTurnText(chatId, state.completedTurnText);
-              if (messageId) {
-                messageId = await this.recreateCard(chatId, messageId, state);
+              turnBuffer += (turnBuffer ? '\n\n---\n\n' : '') + state.completedTurnText;
+              if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
+                await rateLimiter.flush();
+                await this.sendTurnText(chatId, turnBuffer);
+                if (messageId) {
+                  messageId = await this.recreateCard(chatId, messageId, state);
+                }
+                turnBuffer = '';
               }
             }
             const newSid = processor.getSessionId();
@@ -1467,6 +1515,11 @@ export class MessageBridge {
           }
           await rateLimiter.cancelAndWait();
 
+          if (turnBuffer && chatId && messageId) {
+            await this.sendTurnText(chatId, turnBuffer);
+            messageId = await this.recreateCard(chatId, messageId, lastState);
+            turnBuffer = '';
+          }
           if (sendCards && messageId) {
             await this.sendFinalCard(messageId, lastState, chatId);
           }
@@ -1502,6 +1555,11 @@ export class MessageBridge {
           errorMessage: err.message || 'Unknown error',
         };
         await rateLimiter.cancelAndWait();
+        if (turnBuffer && chatId && messageId) {
+          await this.sendTurnText(chatId, turnBuffer);
+          messageId = await this.recreateCard(chatId, messageId, lastState);
+          turnBuffer = '';
+        }
         await this.sendFinalCard(messageId, errorState, chatId);
       }
 

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -948,10 +948,9 @@ export class MessageBridge {
         await rateLimiter.cancelAndWait();
       }
 
-      // Flush remaining turn buffer before final card
+      // Flush remaining turn buffer before final card (no recreate — final card updates in place)
       if (turnBuffer && chatId) {
         if (await this.sendTurnText(chatId, turnBuffer)) {
-          messageId = await this.recreateCard(chatId, messageId, lastState);
           turnBuffer = '';
         }
       }
@@ -1029,7 +1028,6 @@ export class MessageBridge {
           await rateLimiter.cancelAndWait();
           if (turnBuffer && chatId) {
             if (await this.sendTurnText(chatId, turnBuffer)) {
-              messageId = await this.recreateCard(chatId, messageId, lastState);
               turnBuffer = '';
             }
           }
@@ -1085,7 +1083,6 @@ export class MessageBridge {
       await rateLimiter.cancelAndWait();
       if (turnBuffer && chatId) {
         if (await this.sendTurnText(chatId, turnBuffer)) {
-          messageId = await this.recreateCard(chatId, messageId, lastState);
           turnBuffer = '';
         }
       }
@@ -1435,7 +1432,6 @@ export class MessageBridge {
 
       if (turnBuffer && chatId && messageId) {
         if (await this.sendTurnText(chatId, turnBuffer)) {
-          messageId = await this.recreateCard(chatId, messageId, lastState);
           turnBuffer = '';
         }
       }
@@ -1527,7 +1523,6 @@ export class MessageBridge {
 
           if (turnBuffer && chatId && messageId) {
             if (await this.sendTurnText(chatId, turnBuffer)) {
-              messageId = await this.recreateCard(chatId, messageId, lastState);
               turnBuffer = '';
             }
           }
@@ -1568,7 +1563,6 @@ export class MessageBridge {
         await rateLimiter.cancelAndWait();
         if (turnBuffer && chatId && messageId) {
           if (await this.sendTurnText(chatId, turnBuffer)) {
-            messageId = await this.recreateCard(chatId, messageId, lastState);
             turnBuffer = '';
           }
         }

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -641,12 +641,14 @@ export class MessageBridge {
       startTime: taskStartTime,
     };
 
-    const messageId = await this.sender.sendCard(chatId, initialState);
+    const initialCardId = await this.sender.sendCard(chatId, initialState);
 
-    if (!messageId) {
+    if (!initialCardId) {
       this.logger.error('Failed to send initial card, aborting');
       return;
     }
+
+    let messageId: string = initialCardId;
 
     const apiContext = { botName: this.config.name, chatId };
 
@@ -733,6 +735,7 @@ export class MessageBridge {
             if (state.completedTurnText && chatId) {
               await rateLimiter.flush();
               await this.sendTurnText(chatId, state.completedTurnText);
+              messageId = await this.recreateCard(chatId, messageId, state);
             }
 
             // Update session ID if discovered
@@ -923,6 +926,7 @@ export class MessageBridge {
           if (state.completedTurnText && chatId) {
             await rateLimiter.flush();
             await this.sendTurnText(chatId, state.completedTurnText);
+            messageId = await this.recreateCard(chatId, messageId, state);
           }
           const newSid = processor.getSessionId();
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
@@ -991,6 +995,7 @@ export class MessageBridge {
             if (state.completedTurnText && chatId) {
               await rateLimiter.flush();
               await this.sendTurnText(chatId, state.completedTurnText);
+              messageId = await this.recreateCard(chatId, messageId, state);
             }
             const newSid = processor.getSessionId();
             if (newSid) this.sessionManager.setSessionId(chatId, newSid);
@@ -1220,6 +1225,9 @@ export class MessageBridge {
             if (state.completedTurnText && chatId) {
               await rateLimiter.flush();
               await this.sendTurnText(chatId, state.completedTurnText);
+              if (messageId) {
+                messageId = await this.recreateCard(chatId, messageId, state);
+              }
             }
 
             const newSessionId = processor.getSessionId();
@@ -1363,6 +1371,9 @@ export class MessageBridge {
           if (state.completedTurnText && chatId) {
             await rateLimiter.flush();
             await this.sendTurnText(chatId, state.completedTurnText);
+            if (messageId) {
+              messageId = await this.recreateCard(chatId, messageId, state);
+            }
           }
           const newSid = processor.getSessionId();
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
@@ -1442,6 +1453,9 @@ export class MessageBridge {
             if (state.completedTurnText && chatId) {
               await rateLimiter.flush();
               await this.sendTurnText(chatId, state.completedTurnText);
+              if (messageId) {
+                messageId = await this.recreateCard(chatId, messageId, state);
+              }
             }
             const newSid = processor.getSessionId();
             if (newSid) this.sessionManager.setSessionId(chatId, newSid);
@@ -1582,6 +1596,29 @@ export class MessageBridge {
         this.logger.warn({ err, chatId, chunk: i + 1, total }, 'Failed to send turn text');
       }
     }
+  }
+
+  /**
+   * Freeze old card and create a new one at the bottom so the card stays below 💬 messages.
+   * Returns the new messageId, or the old one if card creation failed.
+   */
+  private async recreateCard(chatId: string, oldMessageId: string, state: CardState): Promise<string> {
+    // Freeze old card: clear response text (already sent as 💬)
+    try {
+      await this.sender.updateCard(oldMessageId, { ...state, responseText: '' });
+    } catch { /* best effort */ }
+    // Create new card at bottom for next turn
+    try {
+      const newId = await this.sender.sendCard(chatId, {
+        status: 'thinking',
+        userPrompt: state.userPrompt,
+        responseText: '',
+        toolCalls: [],
+        startTime: state.startTime,
+      });
+      if (newId) return newId;
+    } catch { /* fall back to old card */ }
+    return oldMessageId;
   }
 
   /**

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -652,6 +652,7 @@ export class MessageBridge {
     let messageId: string = initialCardId;
     let turnBuffer = '';
     let turnCount = 0;
+    let needsRecreate = false;
 
     const apiContext = { botName: this.config.name, chatId };
 
@@ -740,7 +741,7 @@ export class MessageBridge {
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
                 if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+                  needsRecreate = true;
                   turnBuffer = '';
                 }
               }
@@ -842,6 +843,13 @@ export class MessageBridge {
               break;
             }
 
+            // Deferred recreate: move card to bottom when new content starts after turn flush
+            if (needsRecreate && state.responseText) {
+              await rateLimiter.flush();
+              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+              needsRecreate = false;
+            }
+
             // Throttled card update for non-final states
             rateLimiter.schedule(() => {
               this.sender.updateCard(messageId, state).catch(() => {});
@@ -936,7 +944,7 @@ export class MessageBridge {
             if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
               if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+                needsRecreate = true;
                 turnBuffer = '';
               }
             }
@@ -944,6 +952,11 @@ export class MessageBridge {
           const newSid = processor.getSessionId();
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
           if (state.status === 'complete' || state.status === 'error') break;
+          if (needsRecreate && state.responseText) {
+            await rateLimiter.flush();
+            messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+            needsRecreate = false;
+          }
           rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
         }
         await rateLimiter.cancelAndWait();
@@ -1016,7 +1029,7 @@ export class MessageBridge {
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
                 if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+                  needsRecreate = true;
                   turnBuffer = '';
                 }
               }
@@ -1024,6 +1037,11 @@ export class MessageBridge {
             const newSid = processor.getSessionId();
             if (newSid) this.sessionManager.setSessionId(chatId, newSid);
             if (state.status === 'complete' || state.status === 'error') break;
+            if (needsRecreate && state.responseText) {
+              await rateLimiter.flush();
+              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+              needsRecreate = false;
+            }
             rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
           }
           await rateLimiter.cancelAndWait();
@@ -1174,6 +1192,7 @@ export class MessageBridge {
     let messageId: string | undefined;
     let turnBuffer = '';
     let turnCount = 0;
+    let needsRecreate = false;
     if (sendCards) {
       messageId = await this.sender.sendCard(chatId, initialState);
     }
@@ -1263,9 +1282,7 @@ export class MessageBridge {
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
                 if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  if (messageId) {
-                    messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
-                  }
+                  needsRecreate = true;
                   turnBuffer = '';
                 }
               }
@@ -1323,6 +1340,11 @@ export class MessageBridge {
             }
 
             if (sendCards && messageId) {
+              if (needsRecreate && state.responseText) {
+                await rateLimiter.flush();
+                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+                needsRecreate = false;
+              }
               rateLimiter.schedule(() => {
                 this.sender.updateCard(messageId!, state).catch(() => {});
               });
@@ -1414,9 +1436,7 @@ export class MessageBridge {
             if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
               await rateLimiter.flush();
               if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                if (messageId) {
-                  messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
-                }
+                needsRecreate = true;
                 turnBuffer = '';
               }
             }
@@ -1425,6 +1445,11 @@ export class MessageBridge {
           if (newSid) this.sessionManager.setSessionId(chatId, newSid);
           if (state.status === 'complete' || state.status === 'error') break;
           if (sendCards && messageId) {
+            if (needsRecreate && state.responseText) {
+              await rateLimiter.flush();
+              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+              needsRecreate = false;
+            }
             rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
           }
           options.onUpdate?.(state, effectiveMessageId, false);
@@ -1506,9 +1531,7 @@ export class MessageBridge {
               if (turnBuffer.length >= TURN_MERGE_THRESHOLD) {
                 await rateLimiter.flush();
                 if (await this.sendTurnText(chatId, turnBuffer, `💬 Turn ${++turnCount}`)) {
-                  if (messageId) {
-                    messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
-                  }
+                  needsRecreate = true;
                   turnBuffer = '';
                 }
               }
@@ -1517,6 +1540,11 @@ export class MessageBridge {
             if (newSid) this.sessionManager.setSessionId(chatId, newSid);
             if (state.status === 'complete' || state.status === 'error') break;
             if (sendCards && messageId) {
+              if (needsRecreate && state.responseText) {
+                await rateLimiter.flush();
+                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`);
+                needsRecreate = false;
+              }
               rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
             }
             options.onUpdate?.(state, effectiveMessageId, false);
@@ -1607,8 +1635,10 @@ export class MessageBridge {
    * sends a plain text fallback so the user at least sees the result.
    */
   private async sendFinalCard(messageId: string, state: CardState, chatId?: string, unsentText?: string): Promise<void> {
-    // If there's unsent turn text (💬 failed), fall back to showing it in the card
-    const cardState = { ...state, responseText: unsentText || '', cardTitle: '📊 Result' };
+    // If there's unsent turn text (💬 failed), fall back to showing it in the card.
+    // If no content at all, show a pointer to the 💬 messages above.
+    const displayText = unsentText || state.responseText || '_See 💬 messages above for full response_';
+    const cardState = { ...state, responseText: displayText, cardTitle: '📊 Result' };
 
     let updateSucceeded = false;
     for (let attempt = 0; attempt < FINAL_CARD_RETRIES; attempt++) {

--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -31,6 +31,8 @@ export class StreamProcessor {
   private thinkingText = '';
   /** Text from the just-completed turn, consumed by the bridge after sending */
   private _completedTurnText: string | undefined;
+  /** Last turn text emitted, used to deduplicate against SDK result */
+  private _lastSentTurnText: string | undefined;
   /** SDK result text, stored separately so it doesn't overwrite responseText */
   private _resultSummary: string | undefined;
   private toolCalls: ToolCall[] = [];
@@ -169,6 +171,7 @@ export class StreamProcessor {
         // Emit completed turn text for the bridge to send as a separate message.
         // Then reset responseText so the card is clean for the next turn's streaming.
         this._completedTurnText = block.text;
+        this._lastSentTurnText = block.text;
         this.responseText = '';
       } else if (block.type === 'tool_use' && block.name) {
         this.addToolCall(block.name, block.input);
@@ -376,9 +379,9 @@ export class StreamProcessor {
     // SDK sometimes wraps API errors as "success" with the error text as result
     const isApiError = !isError && isApiErrorResult(resultText);
 
-    // Store result separately — it will be sent as its own message with stats.
-    // Don't overwrite responseText (which is empty after per-turn emission).
-    this._resultSummary = resultText || undefined;
+    // Store result separately — only if it differs from the last turn text already sent.
+    // SDK result often echoes the last assistant message; skip to avoid duplication.
+    this._resultSummary = (resultText && resultText !== this._lastSentTurnText) ? resultText : undefined;
 
     return {
       status: (isError || isApiError) ? 'error' : 'complete',

--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -29,6 +29,10 @@ export interface StreamProcessorConfig {
 export class StreamProcessor {
   private responseText = '';
   private thinkingText = '';
+  /** Text from the just-completed turn, consumed by the bridge after sending */
+  private _completedTurnText: string | undefined;
+  /** SDK result text, stored separately so it doesn't overwrite responseText */
+  private _resultSummary: string | undefined;
   private toolCalls: ToolCall[] = [];
   private toolSummaries: string[] = [];
   private subagentTasks: Map<string, SubagentTask> = new Map();
@@ -101,15 +105,21 @@ export class StreamProcessor {
     }
 
     // Determine running status
+    // Determine running status
     const hasActiveTools = this.toolCalls.some((t) => t.status === 'running');
     const status = this._pendingQuestions.length > 0
       ? 'waiting_for_input'
       : hasActiveTools ? 'running' : this.responseText ? 'running' : 'thinking';
 
+    // Capture and clear completedTurnText so it's only emitted once
+    const turnText = this._completedTurnText;
+    this._completedTurnText = undefined;
+
     return {
       status,
       userPrompt: this.userPrompt,
       responseText: this.responseText,
+      completedTurnText: turnText,
       thinkingText: this.thinkingText || undefined,
       toolCalls: [...this.toolCalls],
       toolSummaries: this.toolSummaries.length > 0 ? [...this.toolSummaries] : undefined,
@@ -156,8 +166,10 @@ export class StreamProcessor {
       if (block.type === 'thinking' && block.thinking) {
         this.thinkingText = block.thinking;
       } else if (block.type === 'text' && block.text) {
-        // Full message text replaces accumulated stream text
-        this.responseText = block.text;
+        // Emit completed turn text for the bridge to send as a separate message.
+        // Then reset responseText so the card is clean for the next turn's streaming.
+        this._completedTurnText = block.text;
+        this.responseText = '';
       } else if (block.type === 'tool_use' && block.name) {
         this.addToolCall(block.name, block.input);
         if (block.name === 'AskUserQuestion' && block.id && block.input) {
@@ -359,15 +371,20 @@ export class StreamProcessor {
       tool.status = 'done';
     }
 
-    const resultText = message.result || this.responseText;
+    const resultText = message.result || '';
     const isError = message.subtype !== 'success';
     // SDK sometimes wraps API errors as "success" with the error text as result
     const isApiError = !isError && isApiErrorResult(resultText);
 
+    // Store result separately — it will be sent as its own message with stats.
+    // Don't overwrite responseText (which is empty after per-turn emission).
+    this._resultSummary = resultText || undefined;
+
     return {
       status: (isError || isApiError) ? 'error' : 'complete',
       userPrompt: this.userPrompt,
-      responseText: isApiError ? '' : resultText,
+      responseText: '',
+      resultSummary: isApiError ? undefined : this._resultSummary,
       thinkingText: this.thinkingText || undefined,
       toolCalls: [...this.toolCalls],
       toolSummaries: this.toolSummaries.length > 0 ? [...this.toolSummaries] : undefined,

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -420,9 +420,11 @@ export function buildCard(state: CardState): string {
     header: {
       template: config.color,
       title: {
-        content: elapsed && (state.status === 'thinking' || state.status === 'running')
-          ? `${config.icon} ${config.title} (${elapsed})`
-          : `${config.icon} ${config.title}`,
+        content: state.cardTitle
+          ? `${config.icon} ${state.cardTitle}`
+          : elapsed && (state.status === 'thinking' || state.status === 'running')
+            ? `${config.icon} ${config.title} (${elapsed})`
+            : `${config.icon} ${config.title}`,
         tag: 'plain_text',
       },
     },

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -508,12 +508,7 @@ export function buildTextCard(title: string, content: string, color: string = 'b
         tag: 'plain_text',
       },
     },
-    elements: [
-      {
-        tag: 'markdown',
-        content,
-      },
-    ],
+    elements: splitMarkdownWithTables(content),
   };
   return JSON.stringify(card);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,10 @@ export interface CardState {
   totalTokens?: number;
   /** Context window size of the primary model */
   contextWindow?: number;
+  /** Text from a just-completed assistant turn, ready to be sent as a separate message */
+  completedTurnText?: string;
+  /** SDK result text, sent as a separate message with stats at completion */
+  resultSummary?: string;
 }
 
 export interface IncomingMessage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,8 @@ export interface CardState {
   completedTurnText?: string;
   /** SDK result text, sent as a separate message with stats at completion */
   resultSummary?: string;
+  /** Custom card header title override (e.g. "Turn 1", "📊 Result") */
+  cardTitle?: string;
 }
 
 export interface IncomingMessage {

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -127,6 +127,43 @@ describe('buildCard', () => {
     const md = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('truncated'));
     expect(md).toBeDefined();
   });
+
+  it('uses cardTitle to override default header title', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'task',
+      responseText: '_See 💬 messages above for full response_',
+      toolCalls: [],
+      cardTitle: '📊 Result',
+    };
+    const json = JSON.parse(buildCard(state));
+    expect(json.header.title.content).toBe('🟢 📊 Result');
+  });
+
+  it('uses cardTitle for frozen turn card (e.g. Turn 1)', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+      cardTitle: 'Turn 1',
+    };
+    const json = JSON.parse(buildCard(state));
+    expect(json.header.title.content).toBe('🟢 Turn 1');
+  });
+
+  it('shows thinking placeholder when status is thinking and no responseText', () => {
+    const state: CardState = {
+      status: 'thinking',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+      startTime: Date.now(),
+    };
+    const json = JSON.parse(buildCard(state));
+    const md = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('thinking'));
+    expect(md).toBeDefined();
+  });
 });
 
 describe('buildHelpCard', () => {

--- a/tests/card-flow.test.ts
+++ b/tests/card-flow.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration-style tests for the card flow:
+ * - Turn content is embedded in frozen cards (not sent as separate text messages)
+ * - Result card is always sent at the bottom (after all turn cards)
+ * - Single-turn tasks update the existing card in place
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { IMessageSender } from '../src/bridge/message-sender.interface.js';
+import type { CardState } from '../src/types.js';
+import { MessageBridge } from '../src/bridge/message-bridge.js';
+
+function mockConfig() {
+  return {
+    name: 'test-bot',
+    claude: {
+      defaultWorkingDirectory: '/tmp/test',
+      maxTurns: 10,
+      maxBudgetUsd: 1,
+      model: undefined,
+      thinking: undefined,
+      effort: undefined,
+      apiKey: undefined,
+      outputsBaseDir: '/tmp/test-outputs',
+      downloadsDir: '/tmp/test-downloads',
+    },
+  } as any;
+}
+
+function mockSender() {
+  let cardCounter = 0;
+  const sender: IMessageSender = {
+    sendCard: vi.fn(async () => `card_${++cardCounter}`),
+    updateCard: vi.fn(async () => {}),
+    sendTextNotice: vi.fn(async () => {}),
+    sendText: vi.fn(async () => {}),
+    sendImageFile: vi.fn(async () => true),
+    sendLocalFile: vi.fn(async () => true),
+    downloadImage: vi.fn(async () => true),
+    downloadFile: vi.fn(async () => true),
+  };
+  return sender;
+}
+
+function mockLogger() {
+  const noop = () => {};
+  const logger: any = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return logger;
+}
+
+function makeBridge(sender: IMessageSender) {
+  return new MessageBridge(mockConfig(), mockLogger(), sender, '');
+}
+
+describe('recreateCard — turn content in frozen card', () => {
+  it('freezes old card with turn text and creates new card', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'test',
+      responseText: 'new turn starting...',
+      toolCalls: [],
+      startTime: Date.now(),
+    };
+
+    const turnText = 'This is the completed Turn 1 response with full content.';
+    const newId = await (bridge as any).recreateCard('chat1', 'old_card', state, 'Turn 1', turnText);
+
+    // Old card frozen WITH the turn content (not empty)
+    expect(sender.updateCard).toHaveBeenCalledWith('old_card', expect.objectContaining({
+      status: 'complete',
+      responseText: turnText,
+      cardTitle: 'Turn 1',
+    }));
+
+    // New card created for next turn
+    expect(sender.sendCard).toHaveBeenCalledWith('chat1', expect.objectContaining({
+      status: 'thinking',
+      responseText: '',
+    }));
+
+    expect(newId).toBe('card_1');
+  });
+
+  it('freezes card with empty text when no turnText provided', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    const state: CardState = { status: 'running', userPrompt: 'test', responseText: '', toolCalls: [] };
+    await (bridge as any).recreateCard('chat1', 'old_card', state, 'Turn 1');
+
+    expect(sender.updateCard).toHaveBeenCalledWith('old_card', expect.objectContaining({
+      status: 'complete',
+      responseText: '',
+      cardTitle: 'Turn 1',
+    }));
+  });
+
+  it('retries freeze if first attempt fails', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    let callCount = 0;
+    (sender.updateCard as any).mockImplementation(async () => {
+      if (++callCount === 1) throw new Error('network error');
+    });
+
+    const state: CardState = { status: 'running', userPrompt: 'test', responseText: '', toolCalls: [] };
+    await (bridge as any).recreateCard('chat1', 'old_card', state, 'Turn 1', 'content');
+
+    expect(sender.updateCard).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('sendFinalCard — multi-turn vs single-turn', () => {
+  it('multi-turn: freezes card with last turn content + sends new Result card', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'test',
+      responseText: '',
+      toolCalls: [],
+      resultSummary: 'Task done: 3 files modified.',
+    };
+
+    const lastTurnText = 'This is the final turn response content.';
+    await (bridge as any).sendFinalCard('existing_card', state, 'chat1', lastTurnText, 2);
+
+    // 1) Old card frozen with turn content + label
+    expect(sender.updateCard).toHaveBeenCalledWith('existing_card', expect.objectContaining({
+      status: 'complete',
+      responseText: lastTurnText,
+      cardTitle: 'Turn 2',
+    }));
+
+    // 2) New Result card sent at bottom with resultSummary
+    expect(sender.sendCard).toHaveBeenCalledWith('chat1', expect.objectContaining({
+      responseText: 'Task done: 3 files modified.',
+      cardTitle: '📊 Result',
+    }));
+
+    // 3) No separate text notice for resultSummary
+    expect(sender.sendTextNotice).not.toHaveBeenCalled();
+  });
+
+  it('multi-turn without resultSummary: Result card shows pointer text', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'test',
+      responseText: '',
+      toolCalls: [],
+    };
+
+    await (bridge as any).sendFinalCard('card1', state, 'chat1', 'turn content', 1);
+
+    expect(sender.sendCard).toHaveBeenCalledWith('chat1', expect.objectContaining({
+      responseText: '_See cards above for full response_',
+      cardTitle: '📊 Result',
+    }));
+  });
+
+  it('single-turn: updates existing card in place', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'test',
+      responseText: 'short response',
+      toolCalls: [],
+    };
+
+    await (bridge as any).sendFinalCard('card1', state, 'chat1', undefined, 0);
+
+    // Updates existing card (no new card)
+    expect(sender.updateCard).toHaveBeenCalledWith('card1', expect.objectContaining({
+      responseText: 'short response',
+      cardTitle: '📊 Result',
+    }));
+    expect(sender.sendCard).not.toHaveBeenCalled();
+  });
+
+  it('single-turn with resultSummary: sends summary as separate message', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'test',
+      responseText: '',
+      toolCalls: [],
+      resultSummary: 'All done.',
+    };
+
+    await (bridge as any).sendFinalCard('card1', state, 'chat1', undefined, 0);
+
+    // Summary sent as separate text notice
+    expect(sender.sendTextNotice).toHaveBeenCalledWith(
+      'chat1',
+      '📊 Result',
+      'All done.',
+      'blue',
+    );
+  });
+});

--- a/tests/stream-processor.test.ts
+++ b/tests/stream-processor.test.ts
@@ -71,7 +71,8 @@ describe('StreamProcessor', () => {
       duration_ms: 1200,
     }));
     expect(state.status).toBe('complete');
-    expect(state.responseText).toBe('Done!');
+    expect(state.responseText).toBe('');
+    expect(state.resultSummary).toBe('Done!');
     expect(state.costUsd).toBe(0.05);
     expect(state.durationMs).toBe(1200);
   });
@@ -111,6 +112,40 @@ describe('StreamProcessor', () => {
     }));
     expect(state.status).toBe('error');
     expect(state.errorMessage).toBe('Something failed; Another error');
+  });
+
+  it('deduplicates resultSummary when result matches last turn text', () => {
+    const p = new StreamProcessor('hi');
+    // Simulate assistant message (sets _lastSentTurnText)
+    p.processMessage(msg({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: { content: [{ type: 'text', text: 'The answer is 42.' }] },
+    }));
+    // Result echoes the same text — should be suppressed
+    const state = p.processMessage(msg({
+      type: 'result',
+      subtype: 'success',
+      result: 'The answer is 42.',
+    }));
+    expect(state.status).toBe('complete');
+    expect(state.resultSummary).toBeUndefined();
+  });
+
+  it('keeps resultSummary when result differs from last turn text', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: { content: [{ type: 'text', text: 'Working on it...' }] },
+    }));
+    const state = p.processMessage(msg({
+      type: 'result',
+      subtype: 'success',
+      result: 'Task complete — 3 files modified.',
+    }));
+    expect(state.status).toBe('complete');
+    expect(state.resultSummary).toBe('Task complete — 3 files modified.');
   });
 
   it('detects AskUserQuestion and sets waiting_for_input', () => {


### PR DESCRIPTION
## Summary

Fixes #2 — Multi-turn responses lose earlier content when the final card overwrites everything.

- Each assistant turn's text is now sent as a **separate immutable message** via `sendTurnText`, preventing loss
- The final card becomes **status-only** (tools, thinking, cost) — no response text
- SDK result text is sent as a **separate message** with splitting support for long results
- All 6 stream processing loops in `message-bridge.ts` emit per-turn messages consistently

## Changes

| File | What changed |
|------|-------------|
| `src/types.ts` | Added `completedTurnText` and `resultSummary` to `CardState` |
| `src/claude/stream-processor.ts` | Emit `completedTurnText` per turn, store `resultSummary` separately, reset `responseText` after each turn |
| `src/bridge/message-bridge.ts` | `sendTurnText` method + per-turn sending in all stream loops + `sendFinalCard` now status-only with result sent separately |

## Test plan

- [ ] Single-turn task: verify response appears as one 💬 message, card shows status only
- [ ] Multi-turn task (3+ turns): verify each turn appears as separate 💬 message in order
- [ ] Long response (>28KB): verify splitting works (💬 1/N, 💬 2/N, ...)
- [ ] Error case: verify error card still displays correctly
- [ ] Completion notice (✅ Done) still sends separately for tasks >10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)