### PR TITLE
fix: rate limiter ordering — stale streaming update races freeze

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -719,7 +719,7 @@ export class MessageBridge {
     const thinkingTimerId = setInterval(() => {
       if (lastState.startTime && (lastState.status === 'thinking' || lastState.status === 'running')) {
         // Re-render the card with updated elapsed time
-        rateLimiter.schedule(() => this.sender.updateCard(messageId, lastState));
+        rateLimiter.schedule(() => this.sender.updateCard(messageId, lastState).catch(() => false));
       }
     }, 3000);
 
@@ -846,10 +846,11 @@ export class MessageBridge {
               turnBuffer = '';
             }
 
-            // Throttled card update for non-final states
-            rateLimiter.schedule(() => {
-              this.sender.updateCard(messageId, state).catch(() => {});
-            });
+            // Throttled card update for non-final states. Return the promise
+            // so rateLimiter.flush() can await the in-flight update before
+            // recreateCard freezes the card — otherwise the stale update can
+            // land after the freeze and revert it to thinking/running state.
+            rateLimiter.schedule(() => this.sender.updateCard(messageId, state).catch(() => false));
           }
           // Stream ended normally
           streamDone = true;
@@ -952,7 +953,7 @@ export class MessageBridge {
             needsRecreate = false;
             turnBuffer = '';
           }
-          rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
+          rateLimiter.schedule(() => this.sender.updateCard(messageId, state).catch(() => false));
         }
         await rateLimiter.cancelAndWait();
       }
@@ -1032,7 +1033,7 @@ export class MessageBridge {
               needsRecreate = false;
               turnBuffer = '';
             }
-            rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
+            rateLimiter.schedule(() => this.sender.updateCard(messageId, state).catch(() => false));
           }
           await rateLimiter.cancelAndWait();
           if (turnBuffer && !needsRecreate) ++turnCount;
@@ -1325,9 +1326,7 @@ export class MessageBridge {
                 needsRecreate = false;
                 turnBuffer = '';
               }
-              rateLimiter.schedule(() => {
-                this.sender.updateCard(messageId!, state).catch(() => {});
-              });
+              rateLimiter.schedule(() => this.sender.updateCard(messageId!, state).catch(() => false));
             }
           }
           streamDone = true;
@@ -1429,7 +1428,7 @@ export class MessageBridge {
               needsRecreate = false;
               turnBuffer = '';
             }
-            rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
+            rateLimiter.schedule(() => this.sender.updateCard(messageId!, state).catch(() => false));
           }
           options.onUpdate?.(state, effectiveMessageId, false);
         }
@@ -1519,7 +1518,7 @@ export class MessageBridge {
                 needsRecreate = false;
                 turnBuffer = '';
               }
-              rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
+              rateLimiter.schedule(() => this.sender.updateCard(messageId!, state).catch(() => false));
             }
             options.onUpdate?.(state, effectiveMessageId, false);
           }

--- a/src/bridge/rate-limiter.ts
+++ b/src/bridge/rate-limiter.ts
@@ -2,10 +2,22 @@ export class RateLimiter {
   private pending: (() => unknown | Promise<unknown>) | null = null;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private lastSent = 0;
+  // Cumulative promise representing "all thunks ever fired that have not
+  // been awaited-through by flush/cancelAndWait yet". We chain every fired
+  // thunk into this so the ordering guarantee holds even when thunk A is
+  // still in-flight while thunk B fires on a later immediate-path call
+  // (thunk duration > intervalMs). Without this chaining, inFlight would
+  // only track the last thunk and flush() could return while an older
+  // stale update is still landing on the server — the bug that made
+  // multi-turn frozen cards revert to thinking/running state.
+  private inFlight: Promise<unknown> = Promise.resolve();
 
   constructor(private intervalMs: number = 1500) {}
 
-  // Accepts any thunk; return value is discarded (fire-and-forget throttle).
+  // Thunks may return a value or a Promise. For ordering guarantees (see
+  // `flush`), callers that want the server side to quiesce must return the
+  // underlying Promise from the thunk; a thunk returning undefined will still
+  // throttle correctly but offers no ordering guarantee for its work.
   schedule(fn: () => unknown | Promise<unknown>): void {
     const now = Date.now();
     const elapsed = now - this.lastSent;
@@ -13,7 +25,7 @@ export class RateLimiter {
     if (elapsed >= this.intervalMs) {
       // Can send immediately
       this.lastSent = now;
-      fn();
+      this.track(fn());
     } else {
       // Queue for later, replacing any pending update
       this.pending = fn;
@@ -26,11 +38,24 @@ export class RateLimiter {
             this.lastSent = Date.now();
             const pendingFn = this.pending;
             this.pending = null;
-            pendingFn();
+            this.track(pendingFn());
           }
         }, delay);
       }
     }
+  }
+
+  /**
+   * Chain this thunk's result into the cumulative inFlight promise so flush()
+   * waits for every unsettled thunk, not just the latest. Thunks still
+   * execute concurrently on the network; the chain is only for tracking.
+   * Each individual promise is `.catch`-ed to undefined so a rejected thunk
+   * never leaves inFlight in a rejected state (which would poison flush and
+   * potentially surface as an unhandled rejection).
+   */
+  private track(result: unknown | Promise<unknown>): void {
+    const p = Promise.resolve(result).catch(() => undefined);
+    this.inFlight = Promise.all([this.inFlight, p]).then(() => undefined);
   }
 
   async flush(): Promise<void> {
@@ -42,7 +67,14 @@ export class RateLimiter {
       const fn = this.pending;
       this.pending = null;
       this.lastSent = Date.now();
-      await fn();
+      this.track(fn());
+    }
+    // Snapshot the cumulative promise before awaiting so a concurrent
+    // schedule() can extend inFlight without us clobbering its work.
+    const snapshot = this.inFlight;
+    await snapshot;
+    if (this.inFlight === snapshot) {
+      this.inFlight = Promise.resolve();
     }
   }
 
@@ -57,11 +89,16 @@ export class RateLimiter {
 
   /**
    * Cancel pending update and wait until enough time has passed since the last
-   * successfully sent update. This ensures the next direct send won't be
-   * rate-limited by the receiving platform.
+   * successfully sent update. Also awaits all in-flight thunks so the next
+   * direct send can't lose an ordering race with any of them.
    */
   async cancelAndWait(): Promise<void> {
     this.cancel();
+    const snapshot = this.inFlight;
+    await snapshot;
+    if (this.inFlight === snapshot) {
+      this.inFlight = Promise.resolve();
+    }
     const elapsed = Date.now() - this.lastSent;
     if (elapsed < this.intervalMs) {
       await new Promise((r) => setTimeout(r, this.intervalMs - elapsed));

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -92,4 +92,99 @@ describe('RateLimiter', () => {
     limiter.schedule(fn2);
     expect(fn2).toHaveBeenCalledOnce();
   });
+
+  it('flush awaits the in-flight promise returned by the last thunk', async () => {
+    // Regression guard: before this fix, a scheduled thunk returning a
+    // Promise fired fire-and-forget; flush() returned before the network
+    // call landed, letting a subsequent freeze race with the stale update.
+    vi.useRealTimers();
+    const limiter = new RateLimiter(100);
+
+    let resolveUpdate: () => void = () => {};
+    const updatePromise = new Promise<void>((r) => { resolveUpdate = r; });
+    const order: string[] = [];
+
+    limiter.schedule(() => {
+      order.push('update:start');
+      return updatePromise.then(() => { order.push('update:end'); });
+    });
+
+    const flushP = limiter.flush();
+    // flush must NOT complete while the thunk's promise is unresolved.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(order).toEqual(['update:start']);
+
+    resolveUpdate();
+    await flushP;
+    expect(order).toEqual(['update:start', 'update:end']);
+  });
+
+  it('flush awaits ALL unsettled thunks, not just the most recent one', async () => {
+    // Regression guard for the chaining fix: if thunk A's duration exceeds
+    // intervalMs, thunk B can fire on the immediate path while A is still
+    // in-flight. Without cumulative tracking, inFlight would be overwritten
+    // and flush() could return while A is still racing a subsequent
+    // recreateCard freeze — the original bug this PR fixes.
+    vi.useRealTimers();
+    const limiter = new RateLimiter(50); // short interval so B fires immediately
+
+    let resolveA: () => void = () => {};
+    let resolveB: () => void = () => {};
+    const a = new Promise<void>((r) => { resolveA = r; });
+    const b = new Promise<void>((r) => { resolveB = r; });
+    const order: string[] = [];
+
+    limiter.schedule(() => {
+      order.push('A:start');
+      return a.then(() => order.push('A:end'));
+    });
+    // Wait past intervalMs so the next schedule goes through the immediate path
+    // while A is still unresolved — overlapping in-flight thunks.
+    await new Promise((r) => setTimeout(r, 80));
+    limiter.schedule(() => {
+      order.push('B:start');
+      return b.then(() => order.push('B:end'));
+    });
+
+    const flushP = limiter.flush();
+    let flushResolved = false;
+    flushP.then(() => { flushResolved = true; });
+
+    // Resolve B FIRST. Under the old (broken) "track only latest" logic,
+    // flush would resolve here because inFlight pointed to B. The fix must
+    // still be waiting for A.
+    resolveB();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(flushResolved).toBe(false);
+    expect(order).toContain('B:end');
+    expect(order).not.toContain('A:end');
+
+    // Now resolve A. flush should finally complete.
+    resolveA();
+    await flushP;
+    expect(order).toContain('A:end');
+  });
+
+  it('cancelAndWait awaits in-flight thunk before returning', async () => {
+    vi.useRealTimers();
+    const limiter = new RateLimiter(50);
+
+    let resolveUpdate: () => void = () => {};
+    const updatePromise = new Promise<void>((r) => { resolveUpdate = r; });
+    const order: string[] = [];
+
+    limiter.schedule(() => {
+      order.push('update:start');
+      return updatePromise.then(() => { order.push('update:end'); });
+    });
+
+    const cancelP = limiter.cancelAndWait();
+    await new Promise((r) => setTimeout(r, 20));
+    // cancelAndWait should still be waiting for the in-flight update.
+    expect(order).toEqual(['update:start']);
+
+    resolveUpdate();
+    await cancelP;
+    expect(order).toEqual(['update:start', 'update:end']);
+  });
 });


### PR DESCRIPTION
## Bug

Multi-turn conversations completed correctly (final ✅ Done + 📊 Result card), but prior turn cards stayed stuck showing \"Thinking...\" or \"Running...\" with the old streaming-state body — even though \`recreateCard\` had already been called to freeze them to \`Turn N / complete\`.

See user screenshot from 15:28-15:30 session.

## Root Cause

\`rateLimiter.schedule()\` thunks fire \`updateCard()\` as fire-and-forget — thunk returns void synchronously while the HTTP call continues on the network. \`flush()\` awaited the thunk's synchronous return, so \`await rateLimiter.flush()\` resolved immediately while the streaming update was still in flight. \`recreateCard\` then issued its own \`updateCard(freezeState)\` — both requests raced at the Feishu server; when the stale streaming update landed last, the freeze was overwritten.

## Fix

1. **RateLimiter** now tracks a cumulative \`inFlight\` promise. Every fired thunk is chained via \`Promise.all\` so \`flush()\` / \`cancelAndWait()\` await **all** unsettled thunks, not just the latest. Tracking only the latest would still lose the race when thunk duration > \`intervalMs\` (B overwrites inFlight while A is still in flight).
2. **Snapshot-and-reset pattern** in flush/cancelAndWait prevents dropping references to concurrently-scheduled newer work.
3. **All 7 schedule sites** in \`message-bridge.ts\` now return the promise from \`updateCard\` so tracking sees the real network round-trip.

## Tests

- \`flush awaits the in-flight promise returned by the thunk\` — single-thunk case
- \`flush awaits ALL unsettled thunks\` — overlapping-immediate case (thunk A takes longer than \`intervalMs\`, thunk B fires while A is in-flight)
- \`cancelAndWait awaits in-flight thunk before returning\`

217/217 tests pass. Codex review clean (no blockers/majors).

## Test Plan
- [x] Unit tests for flush/cancelAndWait ordering
- [ ] Manual test in production: multi-turn conversation, verify turn cards freeze correctly with no stuck thinking/running state