### PR TITLE
feat: AskUserQuestion button selection via Feishu card callbacks

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -342,6 +342,67 @@ export class MessageBridge {
     await this.executeQuery(msg);
   }
 
+  /**
+   * Handle a card button click (`card.action.trigger`). Maps the click back
+   * to the running task via `cardMessageId + toolUseId`, then synthesizes a
+   * text answer and reuses the existing `handleAnswer` path. This keeps all
+   * idempotency / multi-question / `answeredToolUseIds` logic centralized.
+   *
+   * Stale clicks (task gone, question already resolved, or toolUseId
+   * mismatch) are no-ops — the user just sees the card move on, which is
+   * the desired behavior.
+   */
+  async handleCardAction(evt: {
+    userId: string;
+    messageId: string;
+    value: Record<string, unknown>;
+  }): Promise<void> {
+    if (evt.value.kind !== 'askuser_answer') {
+      // Unknown action kind — ignore silently. Future action kinds (e.g.
+      // approve/deny buttons) will add their own branches here.
+      return;
+    }
+    const toolUseId = typeof evt.value.toolUseId === 'string' ? evt.value.toolUseId : undefined;
+    const optionIndex = typeof evt.value.optionIndex === 'number' ? evt.value.optionIndex : undefined;
+    if (!toolUseId || optionIndex === undefined || optionIndex < 0) {
+      this.logger.warn({ value: evt.value }, 'askuser_answer action missing toolUseId or optionIndex');
+      return;
+    }
+
+    // Find the task whose card this click came from. We scan by messageId
+    // because runningTasks is keyed by chatId. Match toolUseId to defend
+    // against clicks on stale cards whose task has already moved on to a
+    // different question.
+    let foundChatId: string | undefined;
+    let foundTask: RunningTask | undefined;
+    for (const [chatId, task] of this.runningTasks) {
+      if (task.cardMessageId === evt.messageId && task.pendingQuestion?.toolUseId === toolUseId) {
+        foundChatId = chatId;
+        foundTask = task;
+        break;
+      }
+    }
+    if (!foundTask || !foundChatId) {
+      this.logger.info(
+        { messageId: evt.messageId, toolUseId, optionIndex },
+        'card action for unknown or stale task — ignoring',
+      );
+      return;
+    }
+
+    // Reuse the text-reply path. handleAnswer parses "N" → options[N-1].label
+    // exactly as a user typing the number would, so button and text paths
+    // produce identical state transitions.
+    const syntheticMsg: IncomingMessage = {
+      messageId: `card-action:${toolUseId}:${optionIndex}`,
+      chatId: foundChatId,
+      chatType: 'p2p',
+      userId: evt.userId,
+      text: String(optionIndex + 1),
+    };
+    await this.handleAnswer(syntheticMsg, foundTask);
+  }
+
   private async handleAnswer(msg: IncomingMessage, task: RunningTask): Promise<void> {
     const { chatId, text, imageKey } = msg;
     const pending = task.pendingQuestion!;

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -334,21 +334,46 @@ export function buildCard(state: CardState): string {
     // Only display the first question — the bridge only collects one answer
     // at a time. If Claude batches multiple questions, they will be asked
     // sequentially as Claude re-asks unanswered ones.
-    const questionLines: string[] = [];
     const q = state.pendingQuestion.questions[0];
     if (q) {
-      questionLines.push(`**[${q.header}] ${q.question}**`);
-      questionLines.push('');
-      q.options.forEach((opt, i) => {
-        questionLines.push(`**${i + 1}.** ${opt.label} — _${opt.description}_`);
+      // Question header + text
+      elements.push({
+        tag: 'markdown',
+        content: `**[${q.header}] ${q.question}**`,
       });
-      questionLines.push(`**${q.options.length + 1}.** Other（输入自定义回答）`);
-      questionLines.push('');
+
+      // Option descriptions (shown above buttons so users see what each means)
+      const descLines = q.options
+        .map((opt, i) => `**${i + 1}.** ${opt.label} — _${opt.description}_`)
+        .join('\n');
+      if (descLines) {
+        elements.push({ tag: 'markdown', content: descLines });
+      }
+
+      // Interactive buttons — one per option, value carries toolUseId + index
+      // so the bridge can route the click back to resolveQuestion. Layout
+      // 'flow' wraps buttons naturally; Feishu's own max per row is handled
+      // client-side. Buttons stay interactive only while pendingQuestion is
+      // set — once the bridge resolves the question and re-renders the card
+      // without pendingQuestion, the buttons are gone.
+      elements.push({
+        tag: 'action',
+        layout: 'flow',
+        actions: q.options.map((opt, i) => ({
+          tag: 'button',
+          text: { tag: 'plain_text', content: `${i + 1}. ${opt.label}` },
+          type: 'primary',
+          value: {
+            kind: 'askuser_answer',
+            toolUseId: state.pendingQuestion!.toolUseId,
+            optionIndex: i,
+          },
+        })),
+      });
     }
-    questionLines.push('_回复数字选择，或直接输入自定义答案_');
     elements.push({
       tag: 'markdown',
-      content: questionLines.join('\n'),
+      content: '_点击按钮选择，或直接输入自定义答案_',
     });
   }
 

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -449,7 +449,13 @@ export function buildCard(state: CardState): string {
   }
 
   const card = {
-    config: { wide_screen_mode: true },
+    // update_multi: true is required for interactive cards whose buttons
+    // need to remain valid across multiple card updates (e.g. answering Q1
+    // then re-rendering for Q2). Without it, Feishu returns 108002
+    // ("应用对应的卡片不存在") on the second button click because the
+    // post-update card is treated as a distinct card without the original
+    // button callbacks attached.
+    config: { wide_screen_mode: true, update_multi: true },
     header: {
       template: config.color,
       title: {

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -9,6 +9,21 @@ import type { IncomingMessage } from '../types.js';
 
 export type MessageHandler = (msg: IncomingMessage) => void;
 
+/**
+ * Card action event emitted when a user clicks a button on an interactive card.
+ * Normalized from Feishu's `card.action.trigger` event.
+ */
+export interface CardActionEvent {
+  /** Open ID of the user who clicked */
+  userId: string;
+  /** Message ID of the card that was clicked (matches task.cardMessageId) */
+  messageId: string;
+  /** Application-defined value object set on the button */
+  value: Record<string, unknown>;
+}
+
+export type CardActionHandler = (evt: CardActionEvent) => void;
+
 // Cache for group member counts (to avoid calling Feishu API on every message)
 const MEMBER_COUNT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const memberCountCache = new Map<string, { count: number; ts: number }>();
@@ -66,8 +81,44 @@ export function createEventDispatcher(
   onMessage: MessageHandler,
   botOpenId?: string,
   messageSender?: MessageSender,
+  onCardAction?: CardActionHandler,
 ): lark.EventDispatcher {
   const dispatcher = new lark.EventDispatcher({});
+
+  // Register interactive card callback handler. Feishu sends this event over
+  // the same WS channel as messages (WSClient.handleEventData dispatches
+  // everything to EventDispatcher.invoke). The SDK's IHandles TS type does
+  // not list 'card.action.trigger', but the runtime Map accepts any key, so
+  // we cast. Return shape follows Feishu's card callback contract — a
+  // `toast` tells the client to show a transient notification without
+  // replacing the card.
+  if (onCardAction) {
+    (dispatcher.register as any)({
+      'card.action.trigger': async (data: any) => {
+        try {
+          const userId: string | undefined =
+            data?.operator?.open_id ?? data?.open_id;
+          const messageId: string | undefined =
+            data?.context?.open_message_id ?? data?.open_message_id;
+          const value: Record<string, unknown> | undefined =
+            data?.action?.value ?? data?.event?.action?.value;
+          if (!userId || !messageId || !value || typeof value !== 'object') {
+            logger.warn(
+              { keys: Object.keys(data || {}) },
+              'card.action.trigger missing expected fields',
+            );
+            return { toast: { type: 'warning', content: '无法识别的按钮事件' } };
+          }
+          onCardAction({ userId, messageId, value });
+          // Empty response is accepted by Feishu — no toast, no card update.
+          return {};
+        } catch (err) {
+          logger.error({ err }, 'Error handling card action trigger');
+          return { toast: { type: 'error', content: '处理失败，请稍后重试' } };
+        }
+      },
+    });
+  }
 
   dispatcher.register({
     'im.message.receive_v1': async (data: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,15 @@ async function startFeishuBot(botConfig: BotConfig, logger: Logger, memoryServer
     bridge.handleMessage(msg).catch((err) => {
       botLogger.error({ err, msg }, 'Unhandled error in message bridge');
     });
-  }, botOpenId, rawSender);
+  }, botOpenId, rawSender, (evt) => {
+    // Card button click — route to bridge, sharing the same WS activity
+    // liveness signal as regular messages so the heartbeat doesn't flag
+    // an active-by-buttons-only session as disconnected.
+    handle.lastWsActivity = Date.now();
+    bridge.handleCardAction(evt).catch((err) => {
+      botLogger.error({ err, evt }, 'Unhandled error in card action handler');
+    });
+  });
 
   // Create WebSocket client
   const wsClient = new lark.WSClient({

--- a/tests/askuser-buttons.test.ts
+++ b/tests/askuser-buttons.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for AskUserQuestion card button flow (issue #9).
+ *
+ * Covers:
+ *   - card-builder emits an `action` element with one button per option,
+ *     each button's `value` carrying { kind, toolUseId, optionIndex }
+ *   - bridge.handleCardAction routes clicks by matching
+ *     (cardMessageId, toolUseId) against runningTasks
+ *   - stale / unknown clicks are silent no-ops
+ *   - malformed value payloads are rejected
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { IMessageSender } from '../src/bridge/message-sender.interface.js';
+import { MessageBridge } from '../src/bridge/message-bridge.js';
+
+function mockConfig() {
+  return {
+    name: 'test-bot',
+    claude: {
+      defaultWorkingDirectory: '/tmp/test',
+      maxTurns: 10,
+      maxBudgetUsd: 1,
+      outputsBaseDir: '/tmp/test-outputs',
+      downloadsDir: '/tmp/test-downloads',
+    },
+  } as any;
+}
+
+function mockSender(): IMessageSender {
+  return {
+    sendCard: vi.fn(async () => 'card_1'),
+    updateCard: vi.fn(async () => true),
+    sendTextNotice: vi.fn(async () => {}),
+    sendText: vi.fn(async () => {}),
+    sendImageFile: vi.fn(async () => true),
+    sendLocalFile: vi.fn(async () => true),
+    downloadImage: vi.fn(async () => true),
+    downloadFile: vi.fn(async () => true),
+  };
+}
+
+function mockLogger() {
+  const noop = () => {};
+  const logger: any = {
+    info: noop, warn: noop, error: noop, debug: noop,
+    child: () => logger,
+  };
+  return logger;
+}
+
+function makeBridge(sender: IMessageSender) {
+  return new MessageBridge(mockConfig(), mockLogger(), sender, '');
+}
+
+describe('handleCardAction', () => {
+  it('ignores clicks that do not match any running task (stale card)', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    await bridge.handleCardAction({
+      userId: 'u1',
+      messageId: 'unknown_card',
+      value: { kind: 'askuser_answer', toolUseId: 't1', optionIndex: 0 },
+    });
+
+    // Nothing sent, nothing updated, no throws.
+    expect(sender.updateCard).not.toHaveBeenCalled();
+    expect(sender.sendText).not.toHaveBeenCalled();
+  });
+
+  it('ignores clicks whose toolUseId does not match the task\'s current question', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    // Inject a task with a different toolUseId to simulate the card moving on
+    // to the next question while the old button was still visible on client.
+    const fakeTask: any = {
+      cardMessageId: 'card_abc',
+      pendingQuestion: { toolUseId: 'new_tool_id', questions: [] },
+    };
+    (bridge as any).runningTasks.set('chat_1', fakeTask);
+
+    await bridge.handleCardAction({
+      userId: 'u1',
+      messageId: 'card_abc',
+      value: { kind: 'askuser_answer', toolUseId: 'old_tool_id', optionIndex: 0 },
+    });
+
+    expect(sender.updateCard).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed value payloads', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    await bridge.handleCardAction({
+      userId: 'u1',
+      messageId: 'card_abc',
+      value: { kind: 'askuser_answer' }, // missing toolUseId + optionIndex
+    });
+    await bridge.handleCardAction({
+      userId: 'u1',
+      messageId: 'card_abc',
+      value: { kind: 'askuser_answer', toolUseId: 't1', optionIndex: -1 },
+    });
+
+    expect(sender.updateCard).not.toHaveBeenCalled();
+  });
+
+  it('ignores unknown action kinds (future-proofing)', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    await bridge.handleCardAction({
+      userId: 'u1',
+      messageId: 'card_abc',
+      value: { kind: 'something_else', foo: 'bar' },
+    });
+
+    expect(sender.updateCard).not.toHaveBeenCalled();
+  });
+
+  it('routes a valid click through handleAnswer with synthetic text = (optionIndex + 1)', async () => {
+    const sender = mockSender();
+    const bridge = makeBridge(sender);
+
+    // Spy on the private handleAnswer to confirm routing without needing to
+    // set up a real ExecutionHandle/StreamProcessor.
+    const handleAnswerSpy = vi
+      .spyOn(bridge as any, 'handleAnswer')
+      .mockResolvedValue(undefined);
+
+    const fakeTask: any = {
+      cardMessageId: 'card_abc',
+      pendingQuestion: { toolUseId: 't1', questions: [] },
+    };
+    (bridge as any).runningTasks.set('chat_1', fakeTask);
+
+    await bridge.handleCardAction({
+      userId: 'u1',
+      messageId: 'card_abc',
+      value: { kind: 'askuser_answer', toolUseId: 't1', optionIndex: 2 },
+    });
+
+    expect(handleAnswerSpy).toHaveBeenCalledTimes(1);
+    const [syntheticMsg, passedTask] = handleAnswerSpy.mock.calls[0];
+    expect(passedTask).toBe(fakeTask);
+    expect(syntheticMsg).toMatchObject({
+      chatId: 'chat_1',
+      userId: 'u1',
+      text: '3', // optionIndex 2 → text "3" (1-indexed, reuses number parsing)
+    });
+  });
+});

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -89,7 +89,7 @@ describe('buildCard', () => {
     expect(errEl).toBeDefined();
   });
 
-  it('builds waiting_for_input card with question', () => {
+  it('builds waiting_for_input card with question + interactive buttons', () => {
     const state: CardState = {
       status: 'waiting_for_input',
       userPrompt: 'deploy',
@@ -110,10 +110,41 @@ describe('buildCard', () => {
     };
     const json = JSON.parse(buildCard(state));
     expect(json.header.template).toBe('yellow');
+
+    // Question header rendered as markdown
     const qEl = json.elements.find((e: any) => e.tag === 'markdown' && e.content.includes('Which env?'));
     expect(qEl).toBeDefined();
-    expect(qEl.content).toContain('Production');
-    expect(qEl.content).toContain('Staging');
+
+    // Option descriptions rendered as markdown above buttons
+    const descEl = json.elements.find(
+      (e: any) => e.tag === 'markdown'
+        && e.content.includes('Production')
+        && e.content.includes('Live environment')
+        && e.content.includes('Staging'),
+    );
+    expect(descEl).toBeDefined();
+
+    // Buttons rendered as action element, one per option, each value carrying
+    // toolUseId + optionIndex so the bridge can route the click.
+    const actionEl = json.elements.find((e: any) => e.tag === 'action');
+    expect(actionEl).toBeDefined();
+    expect(actionEl.actions).toHaveLength(2);
+    expect(actionEl.actions[0]).toMatchObject({
+      tag: 'button',
+      text: { tag: 'plain_text', content: '1. Production' },
+      value: { kind: 'askuser_answer', toolUseId: 'q1', optionIndex: 0 },
+    });
+    expect(actionEl.actions[1]).toMatchObject({
+      tag: 'button',
+      text: { tag: 'plain_text', content: '2. Staging' },
+      value: { kind: 'askuser_answer', toolUseId: 'q1', optionIndex: 1 },
+    });
+
+    // Hint note still tells users they can type a custom answer instead.
+    const hint = json.elements.find(
+      (e: any) => e.tag === 'markdown' && e.content.includes('自定义答案'),
+    );
+    expect(hint).toBeDefined();
   });
 
   it('truncates long content', () => {


### PR DESCRIPTION
Closes #9

## Summary

Replace markdown-list question options with interactive Feishu card buttons. Clicking a button resolves the question with the same semantics as typing the option's number.

## How

- `card-builder.ts` — `pendingQuestion` renders as `action` element with one `button` per option; each `value` carries `{ kind: 'askuser_answer', toolUseId, optionIndex }`
- `event-handler.ts` — new `CardActionEvent` type; `createEventDispatcher` accepts `onCardAction` callback; registers `card.action.trigger` on the dispatcher (cast required — SDK's `IHandles` type omits this event, but runtime Map accepts arbitrary keys)
- `message-bridge.ts` — new `handleCardAction()` method maps click via `(cardMessageId, toolUseId)` → synthesizes text `String(optionIndex + 1)` → reuses `handleAnswer` path so all multi-question sequencing, idempotency (from #7), and state transitions stay centralized
- `index.ts` — wires `bridge.handleCardAction` into dispatcher

## Why no HTTP server

`WSClient.handleEventData` dispatches ALL WS events (including card actions) to `EventDispatcher.invoke`. Feishu WS mode auto-handles card callback URL registration.

## Required one-time manual config (Feishu developer console)

- Subscribe event: `card.action.trigger`
- Bot settings: enable **Interactive Card** capability
- Card Request URL: NOT needed (WS mode)

Without these, clicks return Feishu error 200340.

## Test plan

- [x] tsc --noEmit clean
- [x] 5 new `handleCardAction` tests (stale / wrong toolUseId / malformed / unknown kind / valid routing)
- [x] Updated card-builder test for action element + button value shape
- [x] All 219 tests pass
- [ ] Manual Feishu test after merge+restart