### PR TITLE
fix: close recreateCard race — gate thinkingTimer + rate-limiter inFlight tracking

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -776,11 +776,15 @@ export class MessageBridge {
     let lastState: CardState = initialState;
     let retryAttempt = 0;
 
-    // Periodic timer to update card during thinking/running (shows elapsed time)
+    // Periodic timer to update card during thinking/running (shows elapsed time).
+    // The limiter itself drops schedule() calls while paused (see recreateCard
+    // wrapping below), so this timer does not need to know about the recreate
+    // lifecycle — pausing at the critical section is enough to kill the
+    // freeze-race without extra coordination here.
     const thinkingTimerId = setInterval(() => {
       if (lastState.startTime && (lastState.status === 'thinking' || lastState.status === 'running')) {
         // Re-render the card with updated elapsed time
-        rateLimiter.schedule(() => this.sender.updateCard(messageId, lastState));
+        rateLimiter.schedule(() => this.sender.updateCard(messageId, lastState).catch(() => false));
       }
     }, 3000);
 
@@ -899,18 +903,30 @@ export class MessageBridge {
               break;
             }
 
-            // Deferred recreate: move card to bottom when new content starts after turn flush
+            // Deferred recreate: move card to bottom when new content starts after turn flush.
+            // Pause the limiter so the thinkingTimer (and any other concurrent
+            // schedule() caller) cannot enqueue an updateCard(oldMessageId,
+            // runningState) that would land on the server AFTER the freeze
+            // and revert the old card — a race flush() alone cannot close
+            // because new thunks are scheduled DURING recreateCard, outside
+            // flush()'s horizon.
             if (needsRecreate && state.responseText) {
               await rateLimiter.flush();
-              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
+              rateLimiter.pause();
+              try {
+                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
+              } finally {
+                rateLimiter.resume();
+              }
               needsRecreate = false;
               turnBuffer = '';
             }
 
-            // Throttled card update for non-final states
-            rateLimiter.schedule(() => {
-              this.sender.updateCard(messageId, state).catch(() => {});
-            });
+            // Throttled card update for non-final states. Return the promise
+            // so rateLimiter.flush() can await the in-flight update before
+            // recreateCard freezes the card — otherwise the stale update can
+            // land after the freeze and revert it to thinking/running state.
+            rateLimiter.schedule(() => this.sender.updateCard(messageId, state).catch(() => false));
           }
           // Stream ended normally
           streamDone = true;
@@ -1009,11 +1025,16 @@ export class MessageBridge {
           if (state.status === 'complete' || state.status === 'error') break;
           if (needsRecreate && state.responseText) {
             await rateLimiter.flush();
-            messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
+            rateLimiter.pause();
+            try {
+              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
+            } finally {
+              rateLimiter.resume();
+            }
             needsRecreate = false;
             turnBuffer = '';
           }
-          rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
+          rateLimiter.schedule(() => this.sender.updateCard(messageId, state).catch(() => false));
         }
         await rateLimiter.cancelAndWait();
       }
@@ -1089,11 +1110,16 @@ export class MessageBridge {
             if (state.status === 'complete' || state.status === 'error') break;
             if (needsRecreate && state.responseText) {
               await rateLimiter.flush();
-              messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
+              rateLimiter.pause();
+              try {
+                messageId = await this.recreateCard(chatId, messageId, state, `Turn ${turnCount}`, turnBuffer);
+              } finally {
+                rateLimiter.resume();
+              }
               needsRecreate = false;
               turnBuffer = '';
             }
-            rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
+            rateLimiter.schedule(() => this.sender.updateCard(messageId, state).catch(() => false));
           }
           await rateLimiter.cancelAndWait();
           if (turnBuffer && !needsRecreate) ++turnCount;
@@ -1386,9 +1412,7 @@ export class MessageBridge {
                 needsRecreate = false;
                 turnBuffer = '';
               }
-              rateLimiter.schedule(() => {
-                this.sender.updateCard(messageId!, state).catch(() => {});
-              });
+              rateLimiter.schedule(() => this.sender.updateCard(messageId!, state).catch(() => false));
             }
           }
           streamDone = true;
@@ -1490,7 +1514,7 @@ export class MessageBridge {
               needsRecreate = false;
               turnBuffer = '';
             }
-            rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
+            rateLimiter.schedule(() => this.sender.updateCard(messageId!, state).catch(() => false));
           }
           options.onUpdate?.(state, effectiveMessageId, false);
         }
@@ -1580,7 +1604,7 @@ export class MessageBridge {
                 needsRecreate = false;
                 turnBuffer = '';
               }
-              rateLimiter.schedule(() => { this.sender.updateCard(messageId!, state); });
+              rateLimiter.schedule(() => this.sender.updateCard(messageId!, state).catch(() => false));
             }
             options.onUpdate?.(state, effectiveMessageId, false);
           }

--- a/src/bridge/rate-limiter.ts
+++ b/src/bridge/rate-limiter.ts
@@ -2,18 +2,42 @@ export class RateLimiter {
   private pending: (() => unknown | Promise<unknown>) | null = null;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private lastSent = 0;
+  // Cumulative promise representing "all thunks ever fired that have not
+  // been awaited-through by flush/cancelAndWait yet". We chain every fired
+  // thunk into this so the ordering guarantee holds even when thunk A is
+  // still in-flight while thunk B fires on a later immediate-path call
+  // (thunk duration > intervalMs). Without this chaining, inFlight would
+  // only track the last thunk and flush() could return while an older
+  // stale update is still landing on the server — the bug that made
+  // multi-turn frozen cards revert to thinking/running state.
+  private inFlight: Promise<unknown> = Promise.resolve();
+  // When paused, schedule() is a silent no-op and any pending thunk is
+  // dropped. Designed for short critical sections (e.g. recreateCard, where
+  // the caller briefly owns card-state transitions) in which ANY new
+  // updateCard would reference closure-captured state that is about to
+  // become stale — replaying such thunks after resume would reintroduce
+  // the very freeze-race that flush() alone cannot close. See PR #12.
+  private paused = false;
 
   constructor(private intervalMs: number = 1500) {}
 
-  // Accepts any thunk; return value is discarded (fire-and-forget throttle).
+  // Thunks may return a value or a Promise. For ordering guarantees (see
+  // `flush`), callers that want the server side to quiesce must return the
+  // underlying Promise from the thunk; a thunk returning undefined will still
+  // throttle correctly but offers no ordering guarantee for its work.
   schedule(fn: () => unknown | Promise<unknown>): void {
+    // Silent drop while paused — we do NOT queue for resume because the
+    // thunk's closure typically captures variables (messageId, lastState)
+    // that the pausing caller is about to invalidate. Queuing would
+    // replay a stale update after resume and defeat the purpose.
+    if (this.paused) return;
     const now = Date.now();
     const elapsed = now - this.lastSent;
 
     if (elapsed >= this.intervalMs) {
       // Can send immediately
       this.lastSent = now;
-      fn();
+      this.track(fn());
     } else {
       // Queue for later, replacing any pending update
       this.pending = fn;
@@ -22,15 +46,32 @@ export class RateLimiter {
         const delay = this.intervalMs - elapsed;
         this.timer = setTimeout(() => {
           this.timer = null;
+          // Pause can land while the timer is armed; in that case we
+          // already cleared `pending` in pause(), but a double-guard keeps
+          // the timer fully inert.
+          if (this.paused) return;
           if (this.pending) {
             this.lastSent = Date.now();
             const pendingFn = this.pending;
             this.pending = null;
-            pendingFn();
+            this.track(pendingFn());
           }
         }, delay);
       }
     }
+  }
+
+  /**
+   * Chain this thunk's result into the cumulative inFlight promise so flush()
+   * waits for every unsettled thunk, not just the latest. Thunks still
+   * execute concurrently on the network; the chain is only for tracking.
+   * Each individual promise is `.catch`-ed to undefined so a rejected thunk
+   * never leaves inFlight in a rejected state (which would poison flush and
+   * potentially surface as an unhandled rejection).
+   */
+  private track(result: unknown | Promise<unknown>): void {
+    const p = Promise.resolve(result).catch(() => undefined);
+    this.inFlight = Promise.all([this.inFlight, p]).then(() => undefined);
   }
 
   async flush(): Promise<void> {
@@ -42,7 +83,14 @@ export class RateLimiter {
       const fn = this.pending;
       this.pending = null;
       this.lastSent = Date.now();
-      await fn();
+      this.track(fn());
+    }
+    // Snapshot the cumulative promise before awaiting so a concurrent
+    // schedule() can extend inFlight without us clobbering its work.
+    const snapshot = this.inFlight;
+    await snapshot;
+    if (this.inFlight === snapshot) {
+      this.inFlight = Promise.resolve();
     }
   }
 
@@ -57,14 +105,57 @@ export class RateLimiter {
 
   /**
    * Cancel pending update and wait until enough time has passed since the last
-   * successfully sent update. This ensures the next direct send won't be
-   * rate-limited by the receiving platform.
+   * successfully sent update. Also awaits all in-flight thunks so the next
+   * direct send can't lose an ordering race with any of them.
    */
   async cancelAndWait(): Promise<void> {
     this.cancel();
+    const snapshot = this.inFlight;
+    await snapshot;
+    if (this.inFlight === snapshot) {
+      this.inFlight = Promise.resolve();
+    }
     const elapsed = Date.now() - this.lastSent;
     if (elapsed < this.intervalMs) {
       await new Promise((r) => setTimeout(r, this.intervalMs - elapsed));
     }
+  }
+
+  /**
+   * Stop accepting new work. Any pending (queued) thunk is dropped and the
+   * deferred timer is cleared. In-flight thunks are intentionally NOT
+   * cancelled — the caller typically awaits flush() before pausing, and
+   * any lingering requests will settle into the inFlight chain. New
+   * schedule() calls during the paused window become silent no-ops.
+   *
+   * Intended lifecycle:
+   *   await rateLimiter.flush();   // drain anything queued/fired pre-pause
+   *   rateLimiter.pause();         // close the window
+   *   try { ...critical section... }
+   *   finally { rateLimiter.resume(); }
+   */
+  pause(): void {
+    this.paused = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.pending = null;
+  }
+
+  /**
+   * Reopen the limiter. We deliberately do NOT replay anything dropped
+   * during the pause — callers rely on pause() to ELIDE stale updates, not
+   * defer them. After resume, the next schedule() observes the normal
+   * throttling rules; lastSent is preserved so the immediate-path interval
+   * still applies relative to the pre-pause send.
+   */
+  resume(): void {
+    this.paused = false;
+  }
+
+  /** Exposed for tests / diagnostics. */
+  isPaused(): boolean {
+    return this.paused;
   }
 }

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -92,4 +92,222 @@ describe('RateLimiter', () => {
     limiter.schedule(fn2);
     expect(fn2).toHaveBeenCalledOnce();
   });
+
+  it('flush awaits the in-flight promise returned by the last thunk', async () => {
+    // Regression guard: before this fix, a scheduled thunk returning a
+    // Promise fired fire-and-forget; flush() returned before the network
+    // call landed, letting a subsequent freeze race with the stale update.
+    vi.useRealTimers();
+    const limiter = new RateLimiter(100);
+
+    let resolveUpdate: () => void = () => {};
+    const updatePromise = new Promise<void>((r) => { resolveUpdate = r; });
+    const order: string[] = [];
+
+    limiter.schedule(() => {
+      order.push('update:start');
+      return updatePromise.then(() => { order.push('update:end'); });
+    });
+
+    const flushP = limiter.flush();
+    // flush must NOT complete while the thunk's promise is unresolved.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(order).toEqual(['update:start']);
+
+    resolveUpdate();
+    await flushP;
+    expect(order).toEqual(['update:start', 'update:end']);
+  });
+
+  it('flush awaits ALL unsettled thunks, not just the most recent one', async () => {
+    // Regression guard for the chaining fix: if thunk A's duration exceeds
+    // intervalMs, thunk B can fire on the immediate path while A is still
+    // in-flight. Without cumulative tracking, inFlight would be overwritten
+    // and flush() could return while A is still racing a subsequent
+    // recreateCard freeze — the original bug this PR fixes.
+    vi.useRealTimers();
+    const limiter = new RateLimiter(50); // short interval so B fires immediately
+
+    let resolveA: () => void = () => {};
+    let resolveB: () => void = () => {};
+    const a = new Promise<void>((r) => { resolveA = r; });
+    const b = new Promise<void>((r) => { resolveB = r; });
+    const order: string[] = [];
+
+    limiter.schedule(() => {
+      order.push('A:start');
+      return a.then(() => order.push('A:end'));
+    });
+    // Wait past intervalMs so the next schedule goes through the immediate path
+    // while A is still unresolved — overlapping in-flight thunks.
+    await new Promise((r) => setTimeout(r, 80));
+    limiter.schedule(() => {
+      order.push('B:start');
+      return b.then(() => order.push('B:end'));
+    });
+
+    const flushP = limiter.flush();
+    let flushResolved = false;
+    flushP.then(() => { flushResolved = true; });
+
+    // Resolve B FIRST. Under the old (broken) "track only latest" logic,
+    // flush would resolve here because inFlight pointed to B. The fix must
+    // still be waiting for A.
+    resolveB();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(flushResolved).toBe(false);
+    expect(order).toContain('B:end');
+    expect(order).not.toContain('A:end');
+
+    // Now resolve A. flush should finally complete.
+    resolveA();
+    await flushP;
+    expect(order).toContain('A:end');
+  });
+
+  it('cancelAndWait awaits in-flight thunk before returning', async () => {
+    vi.useRealTimers();
+    const limiter = new RateLimiter(50);
+
+    let resolveUpdate: () => void = () => {};
+    const updatePromise = new Promise<void>((r) => { resolveUpdate = r; });
+    const order: string[] = [];
+
+    limiter.schedule(() => {
+      order.push('update:start');
+      return updatePromise.then(() => { order.push('update:end'); });
+    });
+
+    const cancelP = limiter.cancelAndWait();
+    await new Promise((r) => setTimeout(r, 20));
+    // cancelAndWait should still be waiting for the in-flight update.
+    expect(order).toEqual(['update:start']);
+
+    resolveUpdate();
+    await cancelP;
+    expect(order).toEqual(['update:start', 'update:end']);
+  });
+
+  // pause/resume — closes the new-thunk window during recreateCard that
+  // flush() alone cannot see. See PR #12 / issue #11.
+  describe('pause/resume', () => {
+    it('schedule while paused is a no-op (thunk never fires)', () => {
+      const limiter = new RateLimiter(1000);
+      const fn = vi.fn();
+
+      limiter.pause();
+      limiter.schedule(fn);
+      vi.advanceTimersByTime(5000);
+
+      expect(fn).not.toHaveBeenCalled();
+      expect(limiter.isPaused()).toBe(true);
+    });
+
+    it('pause drops an already-queued pending thunk', () => {
+      const limiter = new RateLimiter(1000);
+      const fn1 = vi.fn();
+      const fn2 = vi.fn();
+
+      limiter.schedule(fn1);           // immediate
+      limiter.schedule(fn2);           // queued
+      limiter.pause();                 // should clear the queue
+      vi.advanceTimersByTime(5000);
+
+      expect(fn1).toHaveBeenCalledOnce();
+      expect(fn2).not.toHaveBeenCalled();
+    });
+
+    it('resume does NOT replay thunks dropped during pause', () => {
+      const limiter = new RateLimiter(1000);
+      const fn = vi.fn();
+
+      limiter.pause();
+      limiter.schedule(fn);
+      limiter.resume();
+      vi.advanceTimersByTime(5000);
+
+      // We explicitly do not replay — callers pause precisely because the
+      // thunk's closure is about to become stale.
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('after resume, new schedule() calls work normally', () => {
+      const limiter = new RateLimiter(1000);
+      const fn1 = vi.fn();
+      const fn2 = vi.fn();
+
+      limiter.pause();
+      limiter.schedule(fn1);           // dropped
+      limiter.resume();
+
+      // Advance past interval so next call takes the immediate path.
+      vi.advanceTimersByTime(1100);
+      limiter.schedule(fn2);
+      expect(fn2).toHaveBeenCalledOnce();
+    });
+
+    it('pause closes the thinkingTimer race: no stale update during recreate', async () => {
+      // This mirrors the real-world scenario from issue #11:
+      // - a periodic "thinking timer" fires schedule() every tick
+      // - the caller pauses across recreateCard to prevent stale thunks
+      // - an await in recreateCard lets the timer tick
+      // Without pause(), the timer's thunk would fire against the OLD card.
+      vi.useRealTimers();
+      const limiter = new RateLimiter(10); // short interval so immediate path is live
+
+      const staleUpdateFn = vi.fn();
+      // Simulate the 3s thinkingTimer at a compressed interval.
+      const timerId = setInterval(() => {
+        limiter.schedule(staleUpdateFn);
+      }, 5);
+
+      // Let the timer tick a few times to seed the limiter.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(staleUpdateFn).toHaveBeenCalled();
+
+      // Enter the critical section: drain anything queued, then pause.
+      // Capture count AFTER flush so the baseline includes flush's final fire.
+      await limiter.flush();
+      const callsBeforePause = staleUpdateFn.mock.calls.length;
+      limiter.pause();
+      try {
+        // Simulate recreateCard taking ~50ms with the timer ticking inside.
+        await new Promise((r) => setTimeout(r, 50));
+      } finally {
+        limiter.resume();
+      }
+      clearInterval(timerId);
+
+      // The timer kept calling schedule() during the pause, but the limiter
+      // dropped them all — staleUpdateFn's call count must not have grown.
+      expect(staleUpdateFn.mock.calls.length).toBe(callsBeforePause);
+    });
+
+    it('flush still works while paused (awaits inFlight, no-ops pending)', async () => {
+      vi.useRealTimers();
+      const limiter = new RateLimiter(50);
+
+      let resolveA: () => void = () => {};
+      const a = new Promise<void>((r) => { resolveA = r; });
+      const order: string[] = [];
+
+      limiter.schedule(() => {
+        order.push('A:start');
+        return a.then(() => order.push('A:end'));
+      });
+
+      // Pause while A is in flight — flush must still await it.
+      limiter.pause();
+      const flushP = limiter.flush();
+      let flushResolved = false;
+      flushP.then(() => { flushResolved = true; });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(flushResolved).toBe(false);
+
+      resolveA();
+      await flushP;
+      expect(order).toEqual(['A:start', 'A:end']);
+    });
+  });
 });


### PR DESCRIPTION
Closes #11. Supersedes the closed PR #8.

## Root cause — two-part race around recreateCard

### Part A · flush() ordering (same as #8)
RateLimiter fired thunks as fire-and-forget; `flush()` awaited the thunk's synchronous return, not its Promise. An in-flight updateCard could still be travelling when `recreateCard` issued the freeze, letting the stale running update land AFTER the freeze on the server and revert the card.

**Fix:** cumulative `inFlight` Promise chain — every fired thunk wrapped via `Promise.all` so `flush()` awaits ALL unsettled work, not just the latest.

### Part B · thinkingTimer scheduling DURING recreateCard (new)
The 3s `thinkingTimer` runs for the entire stream lifetime. During `recreateCard`'s ~200-500ms window (between freeze-complete and sendCard-return), the timer ticks and schedules a fresh `updateCard(messageId, lastState)`. Closure vars still point at the OLD card (messageId reassigned only after recreateCard returns) and OLD running state (lastState mutated inside the for-await loop which is paused). That late thunk hits the server AFTER the freeze — same symptom as Part A, but invisible to `flush()` because it was scheduled AFTER flush returned.

**Fix:** `RateLimiter` gains `pause()` / `resume()`. While paused, `schedule()` silently drops and any queued pending thunk is evicted. Dropped thunks are **not** replayed on resume — callers pause precisely because the closure-captured state is about to become stale.

## Why pause/resume on the limiter (vs. a business-layer flag)
The limiter is the narrowest point every update flows through, so gating here covers any future `schedule()` caller without requiring each call site to know about the critical section. It also matches the limiter's existing role as the single owner of update ordering.

## Changes
- `rate-limiter.ts`: cumulative `inFlight` tracking + `pause()` / `resume()` / `isPaused()`
- `message-bridge.ts` · Feishu flow: 3 `recreateCard` sites wrapped in `pause/resume`; schedule thunks now return the updateCard Promise so flush sees the round-trip
- `rate-limiter.test.ts`: 6 new pause/resume tests including the timer-during-recreate scenario

## Test plan
- [x] `npx vitest run` — 228 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Live test: run a multi-turn conversation; verify Turn N card freezes to "Turn N — Complete" (green) instead of getting stuck on Running/Thinking