### PR TITLE
feat(security): phase 2 — approval engine (FIFO queue + session state)

### DIFF
--- a/src/security/approval-store.ts
+++ b/src/security/approval-store.ts
@@ -1,0 +1,446 @@
+/**
+ * Approval engine — per-session dangerous-command approval state + FIFO queue.
+ *
+ * 1:1 port of Hermes Agent's `tools/approval.py` approval machinery
+ * (`_session_approved`, `_session_yolo`, `_permanent_approved`, `_pending`,
+ * `_gateway_queues`, `_ApprovalEntry`, `promptDangerousApproval`,
+ * `resolveGatewayApproval`, `approveSession`, etc.) translated to the
+ * Node/TypeScript event-loop model.
+ *
+ * Translation notes (Python → Node):
+ *   - Hermes runs agent turns on executor threads and uses
+ *     `threading.Event` to block a thread until `/approve` or `/deny`
+ *     resolves it. Node is single-threaded with an event loop, so we use
+ *     a Promise + external resolver (the moral equivalent of an Event).
+ *   - No `threading.Lock` needed: every method is synchronous w.r.t. the
+ *     event loop, so atomicity is guaranteed between `await` points.
+ *   - `contextvars.ContextVar` is unused here — callers pass `sessionKey`
+ *     explicitly, as the rest of MetaBot already does.
+ *
+ * This module is **stateful but UI-less**. The Feishu card wiring lands in
+ * Phase 3 via the `NotifyCallback` hook. Permanent-approval persistence
+ * lands in Phase 5 via the `permanentStore` constructor option.
+ *
+ * Source: https://github.com/NousResearch/hermes-agent/blob/main/tools/approval.py
+ */
+
+/** The four user choices, identical to Hermes. */
+export type ApprovalChoice = 'once' | 'session' | 'always' | 'deny';
+
+/** Data delivered to the notify callback so it can render a prompt. */
+export interface ApprovalRequest {
+  /** The raw command string the agent wants to run. */
+  command: string;
+  /** Human description of the matched dangerous pattern. */
+  description: string;
+  /** Canonical approval key (same as Hermes `pattern_key` — the description). */
+  patternKey: string;
+}
+
+/**
+ * Callback the gateway (Phase 3 Feishu integration) registers so the engine
+ * can push approval prompts to the user. May be async (its returned Promise
+ * is awaited and its rejection handled). `approvalId` lets the UI correlate
+ * button clicks back to `resolveById`.
+ */
+export type NotifyCallback = (
+  approvalId: string,
+  req: ApprovalRequest,
+) => void | Promise<void>;
+
+/** Optional persistence hook for permanent approvals (wired in Phase 5). */
+export interface PermanentStore {
+  load(): Promise<string[]> | string[];
+  save(keys: string[]): Promise<void> | void;
+}
+
+/** Optional error sink — logger hook for persistence + async notify failures. */
+export type ErrorLogger = (message: string, err: unknown) => void;
+
+export interface ApprovalStoreOptions {
+  permanentStore?: PermanentStore;
+  /** Optional logger used when the notify cb rejects or persistence save fails. */
+  onError?: ErrorLogger;
+  /**
+   * Optional millisecond timeout. If a prompted approval isn't resolved
+   * within this window, it is auto-resolved as `'deny'` (fail-closed).
+   * Mirrors Hermes's `gateway_timeout` wait-loop. Default: no timeout.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Fallback logger: write to stderr. Overridable via `ApprovalStoreOptions.onError`
+ * so tests (and future bridge integration with pino) can capture errors instead.
+ */
+const defaultLogger: ErrorLogger = (message, err) => {
+  // stderr fallback; production call sites pass a pino-backed logger via options.
+  console.error(`[approval-store] ${message}`, err);
+};
+
+interface PendingEntry {
+  id: string;
+  sessionKey: string;
+  request: ApprovalRequest;
+  resolve: (choice: ApprovalChoice) => void;
+  createdAt: number;
+  /** Set to true once resolved; guards against late notify fires & timeouts. */
+  settled: boolean;
+  /** Set if a timeout is armed — cleared on resolution. */
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+}
+
+export class ApprovalStore {
+  private readonly permanentStore?: PermanentStore;
+  private readonly onError: ErrorLogger;
+  private readonly timeoutMs?: number;
+  // -----------------------------------------------------------------------
+  // Per-session state
+  // -----------------------------------------------------------------------
+
+  /** session_key → set of approved pattern keys (Hermes `_session_approved`). */
+  private readonly sessionApproved = new Map<string, Set<string>>();
+
+  /** session_keys that are in YOLO mode (Hermes `_session_yolo`). */
+  private readonly sessionYolo = new Set<string>();
+
+  /** Globally-approved pattern keys (Hermes `_permanent_approved`). */
+  private readonly permanentApproved = new Set<string>();
+
+  // -----------------------------------------------------------------------
+  // FIFO approval queue
+  // -----------------------------------------------------------------------
+
+  /** session_key → ordered list of pending entries (Hermes `_gateway_queues`). */
+  private readonly queues = new Map<string, PendingEntry[]>();
+
+  /** approvalId → entry, for direct resolve-by-id (used by button callbacks). */
+  private readonly byId = new Map<string, PendingEntry>();
+
+  /** session_key → notify callback (Hermes `_gateway_notify_cbs`). */
+  private readonly notifyCbs = new Map<string, NotifyCallback>();
+
+  private nextId = 1;
+
+  /**
+   * Two-arg form kept for backwards compatibility with the early Phase 2
+   * draft; the one-arg options form is preferred.
+   */
+  constructor(options?: ApprovalStoreOptions | PermanentStore) {
+    if (options && typeof (options as PermanentStore).load === 'function') {
+      // Legacy single-arg PermanentStore.
+      this.permanentStore = options as PermanentStore;
+      this.onError = defaultLogger;
+    } else {
+      const opts = (options as ApprovalStoreOptions | undefined) ?? {};
+      this.permanentStore = opts.permanentStore;
+      this.onError = opts.onError ?? defaultLogger;
+      this.timeoutMs = opts.timeoutMs;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Persistence
+  // -----------------------------------------------------------------------
+
+  /** Load permanent approvals from the persistence hook (Phase 5). */
+  async loadPermanent(): Promise<void> {
+    if (!this.permanentStore) return;
+    const keys = await this.permanentStore.load();
+    this.permanentApproved.clear();
+    for (const k of keys) this.permanentApproved.add(k);
+  }
+
+  private async savePermanent(): Promise<void> {
+    if (!this.permanentStore) return;
+    try {
+      await this.permanentStore.save([...this.permanentApproved]);
+    } catch (err) {
+      this.onError('failed to persist permanent approvals', err);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Approval-state queries (fast-path before prompting)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Should this command be auto-approved without prompting?
+   *
+   * Mirrors Hermes's pre-prompt checks: YOLO session, session allowlist,
+   * permanent allowlist.
+   */
+  isPreApproved(sessionKey: string, patternKey: string): boolean {
+    if (this.sessionYolo.has(sessionKey)) return true;
+    if (this.permanentApproved.has(patternKey)) return true;
+    const sessionSet = this.sessionApproved.get(sessionKey);
+    return sessionSet?.has(patternKey) ?? false;
+  }
+
+  // -----------------------------------------------------------------------
+  // Notify-callback registration (Phase 3 wiring)
+  // -----------------------------------------------------------------------
+
+  registerNotify(sessionKey: string, cb: NotifyCallback): void {
+    this.notifyCbs.set(sessionKey, cb);
+  }
+
+  /**
+   * Unregister the notify callback AND resolve every pending approval as
+   * `'deny'` so waiting callers don't hang forever when the session ends.
+   * Mirrors Hermes `unregister_gateway_notify` semantics, but defaults to
+   * deny (safer than Hermes's `event.set()` with undefined `result`).
+   */
+  unregisterNotify(sessionKey: string): void {
+    this.notifyCbs.delete(sessionKey);
+    const queue = this.queues.get(sessionKey);
+    if (!queue) return;
+    for (const entry of queue) {
+      this.byId.delete(entry.id);
+      entry.resolve('deny');
+    }
+    this.queues.delete(sessionKey);
+  }
+
+  // -----------------------------------------------------------------------
+  // Core: prompt the user and block until answered
+  // -----------------------------------------------------------------------
+
+  /**
+   * Block (via Promise) until the user resolves this approval request.
+   *
+   * Enqueues a pending entry, fires the session's notify callback so the UI
+   * surfaces the prompt, and returns a Promise that resolves to the user's
+   * choice. FIFO is preserved — `resolveNext` pops the oldest entry.
+   *
+   * If no notify callback is registered, the Promise resolves to `'deny'`
+   * immediately (fail-closed — safer than hanging forever).
+   */
+  promptApproval(sessionKey: string, request: ApprovalRequest): Promise<ApprovalChoice> {
+    // Fast-path pre-approval (caller should check first, but double-check here).
+    if (this.isPreApproved(sessionKey, request.patternKey)) {
+      return Promise.resolve('once');
+    }
+
+    const cb = this.notifyCbs.get(sessionKey);
+    if (!cb) {
+      // No UI registered for this session — fail closed.
+      return Promise.resolve('deny');
+    }
+
+    return new Promise<ApprovalChoice>((resolve) => {
+      const id = `appr_${this.nextId++}_${Date.now().toString(36)}`;
+      const entry: PendingEntry = {
+        id,
+        sessionKey,
+        request,
+        resolve: (choice) => {
+          if (entry.settled) return;
+          entry.settled = true;
+          if (entry.timeoutHandle) clearTimeout(entry.timeoutHandle);
+          this.byId.delete(id);
+          resolve(choice);
+        },
+        createdAt: Date.now(),
+        settled: false,
+      };
+
+      const queue = this.queues.get(sessionKey) ?? [];
+      queue.push(entry);
+      this.queues.set(sessionKey, queue);
+      this.byId.set(id, entry);
+
+      // Arm the fail-closed timeout (if configured) BEFORE we fire the cb,
+      // so a UI that never comes back doesn't hang the agent forever.
+      if (this.timeoutMs && this.timeoutMs > 0) {
+        entry.timeoutHandle = setTimeout(() => {
+          if (entry.settled) return;
+          this.onError('approval timeout — auto-denying', {
+            approvalId: id,
+            sessionKey,
+            command: request.command,
+            timeoutMs: this.timeoutMs,
+          });
+          this.resolveById(id, 'deny');
+        }, this.timeoutMs);
+        // Don't keep the Node process alive solely for this timer.
+        if (typeof entry.timeoutHandle === 'object' && 'unref' in entry.timeoutHandle) {
+          (entry.timeoutHandle as { unref(): void }).unref();
+        }
+      }
+
+      // Notify asynchronously so the caller gets its Promise first. Guard
+      // against (a) the entry being settled between now and the microtask
+      // (e.g. unregisterNotify denied it) and (b) async-rejection from cb.
+      queueMicrotask(() => {
+        if (entry.settled) return;
+        try {
+          const ret = cb(id, request);
+          if (ret && typeof (ret as Promise<void>).then === 'function') {
+            Promise.resolve(ret).catch((err) => {
+              this.onError('notify cb rejected', err);
+              this.resolveById(id, 'deny');
+            });
+          }
+        } catch (err) {
+          this.onError('notify cb threw', err);
+          this.resolveById(id, 'deny');
+        }
+      });
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Resolution API (driven by UI buttons / text commands)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Resolve a specific pending approval by id. Returns true if the id was
+   * found and resolved, false otherwise. Idempotent — a second call on the
+   * same id is a no-op.
+   *
+   * Also records the approval in session/permanent allowlists when choice
+   * warrants it.
+   */
+  resolveById(approvalId: string, choice: ApprovalChoice): boolean {
+    const entry = this.byId.get(approvalId);
+    if (!entry) return false;
+    this.applyChoice(entry, choice);
+
+    // Remove from the session's FIFO queue.
+    const queue = this.queues.get(entry.sessionKey);
+    if (queue) {
+      const idx = queue.indexOf(entry);
+      if (idx >= 0) queue.splice(idx, 1);
+      if (queue.length === 0) this.queues.delete(entry.sessionKey);
+    }
+
+    entry.resolve(choice);
+    return true;
+  }
+
+  /**
+   * Resolve the oldest pending approval for a session (FIFO).
+   * Mirrors Hermes `resolve_gateway_approval(session_key, choice)`.
+   *
+   * Returns the number of entries resolved (0 or 1).
+   */
+  resolveNext(sessionKey: string, choice: ApprovalChoice): number {
+    const queue = this.queues.get(sessionKey);
+    if (!queue || queue.length === 0) return 0;
+    const entry = queue.shift()!;
+    if (queue.length === 0) this.queues.delete(sessionKey);
+    this.byId.delete(entry.id);
+    this.applyChoice(entry, choice);
+    entry.resolve(choice);
+    return 1;
+  }
+
+  /**
+   * Resolve every pending approval for a session with the same choice.
+   * Mirrors Hermes `resolve_gateway_approval(session_key, choice, resolve_all=True)`.
+   */
+  resolveAll(sessionKey: string, choice: ApprovalChoice): number {
+    const queue = this.queues.get(sessionKey);
+    if (!queue || queue.length === 0) return 0;
+    const entries = queue.splice(0);
+    this.queues.delete(sessionKey);
+    for (const entry of entries) {
+      this.byId.delete(entry.id);
+      this.applyChoice(entry, choice);
+      entry.resolve(choice);
+    }
+    return entries.length;
+  }
+
+  /**
+   * Persist the side-effects of a choice into session/permanent state.
+   * `'once'` and `'deny'` have no persisted side-effects — they bind only
+   * this single request.
+   */
+  private applyChoice(entry: PendingEntry, choice: ApprovalChoice): void {
+    if (choice === 'session') {
+      this.approveForSession(entry.sessionKey, entry.request.patternKey);
+    } else if (choice === 'always') {
+      this.approvePermanent(entry.request.patternKey);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Explicit allowlist mutators (exposed for /approve-style text commands)
+  // -----------------------------------------------------------------------
+
+  approveForSession(sessionKey: string, patternKey: string): void {
+    let set = this.sessionApproved.get(sessionKey);
+    if (!set) {
+      set = new Set();
+      this.sessionApproved.set(sessionKey, set);
+    }
+    set.add(patternKey);
+  }
+
+  approvePermanent(patternKey: string): void {
+    this.permanentApproved.add(patternKey);
+    // Fire-and-forget persistence — errors bubble to caller via unhandled rejection.
+    void this.savePermanent();
+  }
+
+  revokePermanent(patternKey: string): boolean {
+    const removed = this.permanentApproved.delete(patternKey);
+    if (removed) void this.savePermanent();
+    return removed;
+  }
+
+  /**
+   * Wipe all per-session state: approvals, YOLO mode, and any pending
+   * approvals (resolved as `'deny'`). Mirrors Hermes `clear_session`.
+   */
+  clearSession(sessionKey: string): void {
+    this.sessionApproved.delete(sessionKey);
+    this.sessionYolo.delete(sessionKey);
+    const queue = this.queues.get(sessionKey);
+    if (queue) {
+      for (const entry of queue) {
+        this.byId.delete(entry.id);
+        entry.resolve('deny');
+      }
+      this.queues.delete(sessionKey);
+    }
+  }
+
+  setYolo(sessionKey: string, enabled: boolean): void {
+    if (enabled) this.sessionYolo.add(sessionKey);
+    else this.sessionYolo.delete(sessionKey);
+  }
+
+  isYolo(sessionKey: string): boolean {
+    return this.sessionYolo.has(sessionKey);
+  }
+
+  // -----------------------------------------------------------------------
+  // Introspection (for /approvals debug command, tests)
+  // -----------------------------------------------------------------------
+
+  getSessionApprovals(sessionKey: string): string[] {
+    return [...(this.sessionApproved.get(sessionKey) ?? [])];
+  }
+
+  getPermanentApprovals(): string[] {
+    return [...this.permanentApproved];
+  }
+
+  getPendingCount(sessionKey: string): number {
+    return this.queues.get(sessionKey)?.length ?? 0;
+  }
+
+  hasPending(sessionKey: string): boolean {
+    return this.getPendingCount(sessionKey) > 0;
+  }
+}
+
+/**
+ * Process-wide singleton, matching Hermes's module-level state. Tests that
+ * need isolation should instantiate `new ApprovalStore()` directly rather
+ * than using this export.
+ */
+export const approvalStore = new ApprovalStore();

--- a/tests/approval-store.test.ts
+++ b/tests/approval-store.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ApprovalStore,
+  type ApprovalRequest,
+  type NotifyCallback,
+  type PermanentStore,
+} from '../src/security/approval-store.js';
+
+const SESSION = 'chat_A';
+const OTHER_SESSION = 'chat_B';
+
+function mkRequest(patternKey = 'recursive delete'): ApprovalRequest {
+  return { command: 'rm -rf foo', description: patternKey, patternKey };
+}
+
+/** Capturing notify cb — returns the ids it has seen, in order. */
+function makeNotify(): { cb: NotifyCallback; ids: string[]; reqs: ApprovalRequest[] } {
+  const ids: string[] = [];
+  const reqs: ApprovalRequest[] = [];
+  const cb: NotifyCallback = (id, req) => {
+    ids.push(id);
+    reqs.push(req);
+  };
+  return { cb, ids, reqs };
+}
+
+describe('ApprovalStore — pre-approval fast path', () => {
+  it('returns false for unknown session + pattern', () => {
+    const store = new ApprovalStore();
+    expect(store.isPreApproved(SESSION, 'recursive delete')).toBe(false);
+  });
+
+  it('returns true when YOLO is enabled on the session', () => {
+    const store = new ApprovalStore();
+    store.setYolo(SESSION, true);
+    expect(store.isPreApproved(SESSION, 'any key')).toBe(true);
+  });
+
+  it('YOLO toggle off removes the fast-pass', () => {
+    const store = new ApprovalStore();
+    store.setYolo(SESSION, true);
+    store.setYolo(SESSION, false);
+    expect(store.isPreApproved(SESSION, 'any key')).toBe(false);
+  });
+
+  it('returns true for session-approved pattern on that session only', () => {
+    const store = new ApprovalStore();
+    store.approveForSession(SESSION, 'recursive delete');
+    expect(store.isPreApproved(SESSION, 'recursive delete')).toBe(true);
+    expect(store.isPreApproved(OTHER_SESSION, 'recursive delete')).toBe(false);
+  });
+
+  it('returns true for permanently-approved pattern across all sessions', () => {
+    const store = new ApprovalStore();
+    store.approvePermanent('recursive delete');
+    expect(store.isPreApproved(SESSION, 'recursive delete')).toBe(true);
+    expect(store.isPreApproved(OTHER_SESSION, 'recursive delete')).toBe(true);
+  });
+});
+
+describe('ApprovalStore — promptApproval flow', () => {
+  it('resolves with "deny" immediately when no notify cb is registered', async () => {
+    const store = new ApprovalStore();
+    await expect(store.promptApproval(SESSION, mkRequest())).resolves.toBe('deny');
+  });
+
+  it('resolves with "once" immediately when already pre-approved', async () => {
+    const store = new ApprovalStore();
+    store.approvePermanent('recursive delete');
+    await expect(store.promptApproval(SESSION, mkRequest())).resolves.toBe('once');
+  });
+
+  it('fires the notify cb with an approval id and the request', async () => {
+    const store = new ApprovalStore();
+    const { cb, ids, reqs } = makeNotify();
+    store.registerNotify(SESSION, cb);
+    const p = store.promptApproval(SESSION, mkRequest());
+    // Flush the queued microtask that fires the cb.
+    await Promise.resolve();
+    expect(ids).toHaveLength(1);
+    expect(reqs[0].command).toBe('rm -rf foo');
+    store.resolveById(ids[0], 'once');
+    await expect(p).resolves.toBe('once');
+  });
+
+  it('records session/permanent approval based on the choice', async () => {
+    const store = new ApprovalStore();
+    const { cb, ids } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p1 = store.promptApproval(SESSION, mkRequest('rm -r'));
+    await Promise.resolve();
+    store.resolveById(ids[0], 'session');
+    await p1;
+
+    const p2 = store.promptApproval(SESSION, mkRequest('SQL DROP'));
+    await Promise.resolve();
+    store.resolveById(ids[1], 'always');
+    await p2;
+
+    const p3 = store.promptApproval(SESSION, mkRequest('git force push'));
+    await Promise.resolve();
+    store.resolveById(ids[2], 'once');
+    await p3;
+
+    expect(store.getSessionApprovals(SESSION)).toEqual(['rm -r']);
+    expect(store.getPermanentApprovals()).toEqual(['SQL DROP']);
+  });
+
+  it('"deny" choice does NOT record any approval', async () => {
+    const store = new ApprovalStore();
+    const { cb, ids } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p = store.promptApproval(SESSION, mkRequest('rm -r'));
+    await Promise.resolve();
+    store.resolveById(ids[0], 'deny');
+    await expect(p).resolves.toBe('deny');
+
+    expect(store.getSessionApprovals(SESSION)).toEqual([]);
+    expect(store.getPermanentApprovals()).toEqual([]);
+  });
+
+  it('resolveById on unknown id returns false', () => {
+    const store = new ApprovalStore();
+    expect(store.resolveById('nope', 'once')).toBe(false);
+  });
+
+  it('resolveById is idempotent — second call returns false', async () => {
+    const store = new ApprovalStore();
+    const { cb, ids } = makeNotify();
+    store.registerNotify(SESSION, cb);
+    const p = store.promptApproval(SESSION, mkRequest());
+    await Promise.resolve();
+    expect(store.resolveById(ids[0], 'once')).toBe(true);
+    await p;
+    expect(store.resolveById(ids[0], 'once')).toBe(false);
+  });
+
+  it('resolves the promise as "deny" if the notify cb throws', async () => {
+    const onError = vi.fn();
+    const store = new ApprovalStore({ onError });
+    const cb: NotifyCallback = () => {
+      throw new Error('ui down');
+    };
+    store.registerNotify(SESSION, cb);
+    await expect(store.promptApproval(SESSION, mkRequest())).resolves.toBe('deny');
+    expect(onError).toHaveBeenCalledWith('notify cb threw', expect.any(Error));
+  });
+
+  it('resolves the promise as "deny" if an async notify cb rejects', async () => {
+    const onError = vi.fn();
+    const store = new ApprovalStore({ onError });
+    const cb: NotifyCallback = async () => {
+      throw new Error('send failed');
+    };
+    store.registerNotify(SESSION, cb);
+    await expect(store.promptApproval(SESSION, mkRequest())).resolves.toBe('deny');
+    // Drain the catch() handler.
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledWith('notify cb rejected', expect.any(Error));
+  });
+});
+
+describe('ApprovalStore — timeout', () => {
+  it('auto-denies when no resolution arrives within timeoutMs', async () => {
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    const store = new ApprovalStore({ onError, timeoutMs: 5_000 });
+    const { cb } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p = store.promptApproval(SESSION, mkRequest());
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(5_000);
+    await expect(p).resolves.toBe('deny');
+    expect(onError).toHaveBeenCalledWith(
+      'approval timeout — auto-denying',
+      expect.objectContaining({ sessionKey: SESSION }),
+    );
+    vi.useRealTimers();
+  });
+
+  it('does not fire timeout when resolved in time', async () => {
+    vi.useFakeTimers();
+    const store = new ApprovalStore({ timeoutMs: 5_000 });
+    const { cb, ids } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p = store.promptApproval(SESSION, mkRequest());
+    await Promise.resolve();
+    store.resolveById(ids[0], 'once');
+    await expect(p).resolves.toBe('once');
+
+    // Advancing past the timeout must not reopen the promise.
+    vi.advanceTimersByTime(10_000);
+    vi.useRealTimers();
+  });
+});
+
+describe('ApprovalStore — FIFO queue semantics', () => {
+  it('resolveNext resolves the oldest pending approval first', async () => {
+    const store = new ApprovalStore();
+    const { cb, ids } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p1 = store.promptApproval(SESSION, mkRequest('a'));
+    const p2 = store.promptApproval(SESSION, mkRequest('b'));
+    const p3 = store.promptApproval(SESSION, mkRequest('c'));
+    await Promise.resolve();
+    expect(ids).toHaveLength(3);
+
+    expect(store.getPendingCount(SESSION)).toBe(3);
+    expect(store.resolveNext(SESSION, 'once')).toBe(1);
+    await expect(p1).resolves.toBe('once');
+    expect(store.getPendingCount(SESSION)).toBe(2);
+
+    expect(store.resolveNext(SESSION, 'session')).toBe(1);
+    await expect(p2).resolves.toBe('session');
+    expect(store.getPendingCount(SESSION)).toBe(1);
+
+    expect(store.resolveNext(SESSION, 'deny')).toBe(1);
+    await expect(p3).resolves.toBe('deny');
+    expect(store.getPendingCount(SESSION)).toBe(0);
+  });
+
+  it('resolveNext returns 0 when queue is empty', () => {
+    const store = new ApprovalStore();
+    expect(store.resolveNext(SESSION, 'once')).toBe(0);
+  });
+
+  it('resolveAll resolves every pending approval with the same choice', async () => {
+    const store = new ApprovalStore();
+    const { cb } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p1 = store.promptApproval(SESSION, mkRequest('a'));
+    const p2 = store.promptApproval(SESSION, mkRequest('b'));
+    await Promise.resolve();
+
+    expect(store.resolveAll(SESSION, 'once')).toBe(2);
+    await expect(p1).resolves.toBe('once');
+    await expect(p2).resolves.toBe('once');
+    expect(store.getPendingCount(SESSION)).toBe(0);
+  });
+
+  it('queue is isolated per session', async () => {
+    const store = new ApprovalStore();
+    const a = makeNotify();
+    const b = makeNotify();
+    store.registerNotify(SESSION, a.cb);
+    store.registerNotify(OTHER_SESSION, b.cb);
+
+    const pA = store.promptApproval(SESSION, mkRequest('a'));
+    const pB = store.promptApproval(OTHER_SESSION, mkRequest('b'));
+    await Promise.resolve();
+
+    expect(store.getPendingCount(SESSION)).toBe(1);
+    expect(store.getPendingCount(OTHER_SESSION)).toBe(1);
+
+    // Resolving SESSION does not affect OTHER_SESSION.
+    store.resolveNext(SESSION, 'once');
+    await pA;
+    expect(store.getPendingCount(SESSION)).toBe(0);
+    expect(store.getPendingCount(OTHER_SESSION)).toBe(1);
+
+    store.resolveNext(OTHER_SESSION, 'deny');
+    await expect(pB).resolves.toBe('deny');
+  });
+});
+
+describe('ApprovalStore — unregister safety', () => {
+  it('unregisterNotify resolves all pending approvals as "deny"', async () => {
+    const store = new ApprovalStore();
+    const { cb } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p1 = store.promptApproval(SESSION, mkRequest('a'));
+    const p2 = store.promptApproval(SESSION, mkRequest('b'));
+    await Promise.resolve();
+
+    store.unregisterNotify(SESSION);
+    await expect(p1).resolves.toBe('deny');
+    await expect(p2).resolves.toBe('deny');
+    expect(store.getPendingCount(SESSION)).toBe(0);
+  });
+
+  it('unregisterNotify of an unknown session is a no-op', () => {
+    const store = new ApprovalStore();
+    expect(() => store.unregisterNotify('nonexistent')).not.toThrow();
+  });
+
+  it('pre-microtask unregister: cb is never invoked, promise denies', async () => {
+    const store = new ApprovalStore();
+    const cb = vi.fn();
+    store.registerNotify(SESSION, cb);
+
+    const p = store.promptApproval(SESSION, mkRequest());
+    // Deny and unregister before the queueMicrotask that fires the cb runs.
+    store.unregisterNotify(SESSION);
+
+    await expect(p).resolves.toBe('deny');
+    // Drain microtasks — cb must have been skipped because entry was settled.
+    await Promise.resolve();
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe('ApprovalStore — clearSession wipes all per-session state', () => {
+  it('clears approvals, YOLO, and pending (resolving them as deny)', async () => {
+    const store = new ApprovalStore();
+    const { cb } = makeNotify();
+    store.registerNotify(SESSION, cb);
+    store.approveForSession(SESSION, 'other-pat');
+
+    // Start a pending request *before* enabling YOLO so it actually enqueues.
+    const p = store.promptApproval(SESSION, mkRequest('not-approved-yet'));
+    await Promise.resolve();
+    store.setYolo(SESSION, true);
+
+    expect(store.getPendingCount(SESSION)).toBe(1);
+
+    store.clearSession(SESSION);
+
+    expect(store.getSessionApprovals(SESSION)).toEqual([]);
+    expect(store.isYolo(SESSION)).toBe(false);
+    expect(store.getPendingCount(SESSION)).toBe(0);
+    await expect(p).resolves.toBe('deny');
+  });
+});
+
+describe('ApprovalStore — byId consistency under mixed resolution', () => {
+  it('resolveAll purges byId entries too', async () => {
+    const store = new ApprovalStore();
+    const { cb, ids } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p1 = store.promptApproval(SESSION, mkRequest('a'));
+    const p2 = store.promptApproval(SESSION, mkRequest('b'));
+    await Promise.resolve();
+
+    store.resolveAll(SESSION, 'once');
+    await p1;
+    await p2;
+
+    // Re-resolving either stale id must return false (entry gone).
+    expect(store.resolveById(ids[0], 'deny')).toBe(false);
+    expect(store.resolveById(ids[1], 'deny')).toBe(false);
+  });
+
+  it('resolveNext then resolveById on the same (now stale) id returns false', async () => {
+    const store = new ApprovalStore();
+    const { cb, ids } = makeNotify();
+    store.registerNotify(SESSION, cb);
+
+    const p = store.promptApproval(SESSION, mkRequest());
+    await Promise.resolve();
+
+    store.resolveNext(SESSION, 'once');
+    await p;
+
+    expect(store.resolveById(ids[0], 'deny')).toBe(false);
+  });
+});
+
+describe('ApprovalStore — permanent allowlist mutators', () => {
+  it('revokePermanent removes a key and returns true', () => {
+    const store = new ApprovalStore();
+    store.approvePermanent('SQL DROP');
+    expect(store.revokePermanent('SQL DROP')).toBe(true);
+    expect(store.getPermanentApprovals()).toEqual([]);
+  });
+
+  it('revokePermanent on missing key returns false', () => {
+    const store = new ApprovalStore();
+    expect(store.revokePermanent('not-there')).toBe(false);
+  });
+
+  it('clearSession wipes that session but leaves others + permanent intact', () => {
+    const store = new ApprovalStore();
+    store.approveForSession(SESSION, 'a');
+    store.approveForSession(OTHER_SESSION, 'b');
+    store.approvePermanent('c');
+
+    store.clearSession(SESSION);
+    expect(store.getSessionApprovals(SESSION)).toEqual([]);
+    expect(store.getSessionApprovals(OTHER_SESSION)).toEqual(['b']);
+    expect(store.getPermanentApprovals()).toEqual(['c']);
+  });
+});
+
+describe('ApprovalStore — persistence hook', () => {
+  it('loadPermanent populates from the store', async () => {
+    const pstore: PermanentStore = {
+      load: vi.fn().mockResolvedValue(['pat1', 'pat2']),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = new ApprovalStore(pstore);
+    await store.loadPermanent();
+    expect(store.getPermanentApprovals().sort()).toEqual(['pat1', 'pat2']);
+  });
+
+  it('approvePermanent triggers save', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const pstore: PermanentStore = { load: () => [], save };
+    const store = new ApprovalStore(pstore);
+    store.approvePermanent('pat1');
+    // Drain the microtask that fires save().
+    await Promise.resolve();
+    expect(save).toHaveBeenCalledWith(['pat1']);
+  });
+
+  it('revokePermanent triggers save when it removed a key', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const pstore: PermanentStore = { load: () => ['pat1'], save };
+    const store = new ApprovalStore(pstore);
+    await store.loadPermanent();
+    save.mockClear();
+
+    store.revokePermanent('pat1');
+    await Promise.resolve();
+    expect(save).toHaveBeenCalledWith([]);
+  });
+
+  it('revokePermanent does NOT save when key was absent', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const pstore: PermanentStore = { load: () => [], save };
+    const store = new ApprovalStore(pstore);
+    expect(store.revokePermanent('missing')).toBe(false);
+    await Promise.resolve();
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('in-memory mode (no permanentStore) still works', async () => {
+    const store = new ApprovalStore();
+    store.approvePermanent('pat1');
+    expect(store.getPermanentApprovals()).toEqual(['pat1']);
+    await expect(store.loadPermanent()).resolves.toBeUndefined();
+  });
+
+  it('save failure is caught and reported via onError, not thrown', async () => {
+    const onError = vi.fn();
+    const save = vi.fn().mockRejectedValue(new Error('disk full'));
+    const store = new ApprovalStore({
+      permanentStore: { load: () => [], save },
+      onError,
+    });
+    store.approvePermanent('pat1');
+    // In-memory update still succeeded — failure is strictly a logging concern.
+    expect(store.getPermanentApprovals()).toEqual(['pat1']);
+
+    // Drain the rejection + onError handler.
+    await new Promise((r) => setImmediate(r));
+    expect(onError).toHaveBeenCalledWith(
+      'failed to persist permanent approvals',
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Phase 2 of Issue #14 — stateful-but-UI-less approval engine. Phase 3 wires Feishu cards into `NotifyCallback`; Phase 5 wires `config.json` into `PermanentStore`. Based on PR #15 (Phase 1).

- `src/security/approval-store.ts` — 1:1 port of Hermes `tools/approval.py` approval machinery
- `tests/approval-store.test.ts` — 35 unit tests
- 362 project tests pass; lint + tsc clean

## What's included
- **Four-tier choice**: `'once' | 'session' | 'always' | 'deny'` — identical to Hermes.
- **Session state**: per-chat approval allowlist + YOLO toggle.
- **Permanent state**: global allowlist + pluggable `PermanentStore` hook.
- **FIFO queue**: `resolveNext` / `resolveAll` / `resolveById`; `byId` map for button-driven resolution.
- **Fail-closed semantics** (all paths resolve the Promise, never hang):
  - Missing notify cb → deny
  - Sync-throwing cb → deny
  - Async-rejecting cb → deny
  - `unregisterNotify` while pending → deny all
  - `clearSession` while pending → deny all + wipe YOLO
  - `timeoutMs` exhausted → deny

## Codex review findings (addressed in this PR)
- ✅ Async notify cb rejection (previously could hang — now `Promise.resolve(ret).catch`)
- ✅ unregister/microtask race (guard with `entry.settled`)
- ✅ `clearSession` incomplete (now also clears YOLO + pending, matching Hermes)
- ✅ `savePermanent` swallowed errors (now routed via `onError` logger)
- ✅ `timeoutMs` option added — auto-deny + log when UI never responds

## What's NOT in this PR
- Feishu card UI + button callbacks (phase 3)
- Smart Approval via Haiku (phase 4)
- `config.json` persistence glue (phase 5 — hook exists, implementation later)

## Test plan
- [x] `npm test` → 362 passed (23 files)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/security/ tests/` clean
- [x] Codex review applied — see commit message for itemized fixes

## Merge order
This PR targets `feat/dangerous-patterns` (PR #15). After PR #15 merges to main, this PR's base should be retargeted to `main`.

Refs #14