### PR TITLE
feat(security): phase 3 — Feishu approval UI + commands + wiring (#14)

### DIFF
--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -7,11 +7,14 @@ import { MemoryClient } from '../memory/memory-client.js';
 import { AuditLogger } from '../utils/audit-logger.js';
 import type { DocSync } from '../sync/doc-sync.js';
 import { ensureSkillInstalled, ensureSkillsInstalled } from '../utils/skill-installer.js';
+import { approvalStore } from '../security/approval-store.js';
+import type { ApprovalBridge } from '../security/approval-bridge.js';
 
 const CONTRIBUTION_SKILLS = ['report-bug', 'fix-issue', 'request-feature'];
 
 export class CommandHandler {
   private docSync: DocSync | null = null;
+  private approvalBridge: ApprovalBridge | null = null;
 
   constructor(
     private config: BotConfigBase,
@@ -27,6 +30,15 @@ export class CommandHandler {
   /** Set the doc sync service (optional, only available for Feishu bots). */
   setDocSync(docSync: DocSync): void {
     this.docSync = docSync;
+  }
+
+  /**
+   * Bind the dangerous-command approval bridge (optional — only wired on
+   * platforms that support raw cards, currently Feishu). When unset, the
+   * /approve /deny /yolo commands respond with a "not supported" notice.
+   */
+  setApprovalBridge(bridge: ApprovalBridge): void {
+    this.approvalBridge = bridge;
   }
 
   /** Returns true if the message was handled as a command, false otherwise. */
@@ -49,6 +61,8 @@ export class CommandHandler {
           '`/memory` - Memory document commands',
           '`/model [opus|sonnet|haiku]` - View or switch Claude model',
           '`/effort [low|medium|high|max]` - View or switch effort level',
+          '`/approve` / `/deny` - Resolve the oldest pending dangerous-command approval',
+          '`/yolo [on|off]` - Auto-approve dangerous commands (use carefully)',
           '`/help` - Show this help message',
           '',
           '**Usage:**',
@@ -73,6 +87,10 @@ export class CommandHandler {
 
       case '/reset':
         this.sessionManager.resetSession(chatId);
+        // Also clear per-chat approval state (YOLO, session allowlist, any
+        // queued pending approvals). Permanent allowlist is global and
+        // intentionally survives /reset.
+        approvalStore.clearSession(chatId);
         await this.sender.sendTextNotice(chatId, '✅ Session Reset', 'Conversation cleared. Working directory preserved.', 'green');
         return true;
 
@@ -131,6 +149,43 @@ export class CommandHandler {
           await this.sender.sendTextNotice(chatId, '✅ Effort Level Changed', `**${prev}** → **${arg}**`, 'green');
         } else {
           await this.sender.sendTextNotice(chatId, '❌ Invalid Effort Level', `\`${arg}\` is not valid. Use: \`low\`, \`medium\`, \`high\`, or \`max\``, 'red');
+        }
+        return true;
+      }
+
+      case '/approve':
+      case '/deny': {
+        // Resolve the oldest pending dangerous-command approval in this chat.
+        // `/approve` maps to a one-shot 'once' allow; users that want session
+        // or permanent allow should click the corresponding card button.
+        if (!this.approvalBridge) {
+          await this.sender.sendTextNotice(chatId, 'ℹ️ Not Available', 'Approval commands are not supported on this platform.', 'blue');
+          return true;
+        }
+        const choice = cmd.toLowerCase() === '/approve' ? 'once' : 'deny';
+        const resolved = this.approvalBridge.resolveNextByText(chatId, choice as 'once' | 'deny', userId);
+        if (resolved === 0) {
+          await this.sender.sendTextNotice(chatId, 'ℹ️ No Pending Approval', 'There is no dangerous-command approval waiting in this chat.', 'blue');
+        }
+        return true;
+      }
+
+      case '/yolo': {
+        // `/yolo on|off` toggles auto-approval for this chat session.
+        // Without args, reports the current state. YOLO does NOT persist
+        // across sessions — it is cleared on /reset or process restart.
+        const arg = text.slice('/yolo'.length).trim().toLowerCase();
+        if (!arg) {
+          const on = approvalStore.isYolo(chatId);
+          await this.sender.sendTextNotice(chatId, '🤠 YOLO Mode', `Current: **${on ? 'on' : 'off'}**\n\nUsage: \`/yolo on|off\`\n\nWhen on, all dangerous commands auto-approve for this chat.`, on ? 'orange' : 'blue');
+        } else if (arg === 'on') {
+          approvalStore.setYolo(chatId, true);
+          await this.sender.sendTextNotice(chatId, '🤠 YOLO On', 'Dangerous commands will auto-approve for this chat. Use `/yolo off` to disable.', 'orange');
+        } else if (arg === 'off') {
+          approvalStore.setYolo(chatId, false);
+          await this.sender.sendTextNotice(chatId, '✅ YOLO Off', 'Dangerous commands will prompt for approval again.', 'green');
+        } else {
+          await this.sender.sendTextNotice(chatId, '❌ Invalid Argument', `\`${arg}\` is not valid. Use: \`on\` or \`off\``, 'red');
         }
         return true;
       }

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -19,6 +19,9 @@ import { CostTracker } from '../utils/cost-tracker.js';
 import { metrics } from '../utils/metrics.js';
 import { splitResponseText } from '../feishu/card-builder.js';
 import type { SessionRegistry } from '../session/session-registry.js';
+import { approvalStore } from '../security/approval-store.js';
+import { ApprovalBridge, type CardSender } from '../security/approval-bridge.js';
+import { detectDangerousCommand } from '../security/dangerous-patterns.js';
 
 const TASK_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
 const QUESTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes for user to answer
@@ -142,6 +145,7 @@ export class MessageBridge {
   private runningTasks = new Map<string, RunningTask>(); // keyed by chatId
   private messageQueues = new Map<string, IncomingMessage[]>(); // per-chatId message queue
   private pendingBatches = new Map<string, PendingBatch>(); // media debounce batches
+  private approvalBridge?: ApprovalBridge; // dangerous-command approval UI (Feishu only)
   /** Callback for activity lifecycle events (task started/completed/failed). */
   onActivityEvent?: (event: ActivityEventData) => void;
 
@@ -167,6 +171,19 @@ export class MessageBridge {
     );
 
     this.outputHandler = new OutputHandler(logger, sender, this.outputsManager);
+
+    // Dangerous-command approval wiring — only enabled on platforms that
+    // implement sendRawCard / updateRawCard (currently Feishu). Telegram and
+    // other platforms silently degrade: Bash commands still run without the
+    // button-confirmation UI, same as before Issue #14.
+    if (sender.sendRawCard && sender.updateRawCard) {
+      const cardSender: CardSender = {
+        sendCard: (chatId, json) => sender.sendRawCard!(chatId, json),
+        updateCard: (messageId, json) => sender.updateRawCard!(messageId, json),
+      };
+      this.approvalBridge = new ApprovalBridge(approvalStore, cardSender, logger);
+      this.commandHandler.setApprovalBridge(this.approvalBridge);
+    }
   }
 
   /** Emit an activity event if a listener is registered. */
@@ -359,9 +376,14 @@ export class MessageBridge {
     messageId: string;
     value: Record<string, unknown>;
   }): Promise<void> {
+    // Dangerous-command approval buttons — route first so the AskUserQuestion
+    // path below doesn't need to know about this kind. handleButtonClick
+    // returns true if it handled the value.
+    if (this.approvalBridge?.handleButtonClick(evt.value, evt.userId)) {
+      return;
+    }
     if (evt.value.kind !== 'askuser_answer') {
-      // Unknown action kind — ignore silently. Future action kinds (e.g.
-      // approve/deny buttons) will add their own branches here.
+      // Unknown action kind — ignore silently.
       return;
     }
     const toolUseId = typeof evt.value.toolUseId === 'string' ? evt.value.toolUseId : undefined;
@@ -718,6 +740,29 @@ export class MessageBridge {
 
     const apiContext = { botName: this.config.name, chatId };
 
+    // Attach the approval bridge for this task's lifetime. detach is called
+    // in the finally block below. When approvalBridge is undefined (platforms
+    // without raw-card support), approvalHandler falls back to 'allow' and
+    // the system behaves as before Issue #14.
+    const detachApprovals = this.approvalBridge?.attachToSession(chatId);
+
+    // Per-task Bash approval handler: detect dangerous patterns, consult the
+    // pre-approval cache, and prompt the user via the approval card if neither
+    // applies. YOLO mode short-circuits inside approvalStore.promptApproval.
+    const approvalHandler = this.approvalBridge
+      ? async (command: string): Promise<'allow' | 'deny'> => {
+          const detection = detectDangerousCommand(command);
+          if (!detection.matched) return 'allow';
+          if (approvalStore.isPreApproved(chatId, detection.patternKey)) return 'allow';
+          const choice = await approvalStore.promptApproval(chatId, {
+            command,
+            description: detection.description,
+            patternKey: detection.patternKey,
+          });
+          return choice === 'deny' ? 'deny' : 'allow';
+        }
+      : undefined;
+
     // Start multi-turn execution
     let executionHandle = this.executor.startExecution({
       prompt,
@@ -726,6 +771,7 @@ export class MessageBridge {
       abortController,
       outputsDir,
       apiContext,
+      approvalHandler,
     });
 
     const rateLimiter = new RateLimiter(1500);
@@ -1196,6 +1242,9 @@ export class MessageBridge {
         clearTimeout(runningTask.questionTimeoutId);
       }
       try { executionHandle.finish(); } catch (e) { this.logger.warn({ err: e, chatId }, 'Error finishing execution handle'); }
+      // Detach the approval bridge — unregisters the notify callback and
+      // denies any still-pending approvals so the Bash hook doesn't hang.
+      try { detachApprovals?.(); } catch (e) { this.logger.warn({ err: e, chatId }, 'Error detaching approval bridge'); }
       // Only delete if this is still our task (guards against stopTask race condition)
       if (this.runningTasks.get(chatId) === runningTask) {
         this.runningTasks.delete(chatId);
@@ -1221,6 +1270,9 @@ export class MessageBridge {
     // Clear session before execution so each run starts with a clean context
     if (freshSession) {
       this.sessionManager.resetSession(chatId);
+      // Also clear per-chat approval state so a fresh API run doesn't inherit
+      // YOLO / session allowlist from a previous operator.
+      approvalStore.clearSession(chatId);
       this.logger.info({ chatId }, 'Fresh session: cleared previous session');
     }
 
@@ -1285,6 +1337,23 @@ export class MessageBridge {
 
     const apiContext = { botName: this.config.name, chatId, groupMembers: options.groupMembers, groupId: options.groupId };
 
+    // Same per-task approval wiring as the interactive path — see executeQuery
+    // for the rationale. Safe no-op when approvalBridge is undefined.
+    const detachApprovals = this.approvalBridge?.attachToSession(chatId);
+    const approvalHandler = this.approvalBridge
+      ? async (command: string): Promise<'allow' | 'deny'> => {
+          const detection = detectDangerousCommand(command);
+          if (!detection.matched) return 'allow';
+          if (approvalStore.isPreApproved(chatId, detection.patternKey)) return 'allow';
+          const choice = await approvalStore.promptApproval(chatId, {
+            command,
+            description: detection.description,
+            patternKey: detection.patternKey,
+          });
+          return choice === 'deny' ? 'deny' : 'allow';
+        }
+      : undefined;
+
     let executionHandle = this.executor.startExecution({
       prompt,
       cwd,
@@ -1295,6 +1364,7 @@ export class MessageBridge {
       maxTurns: options.maxTurns,
       model: options.model,
       allowedTools: options.allowedTools,
+      approvalHandler,
     });
 
     const startTime = Date.now();
@@ -1695,6 +1765,7 @@ export class MessageBridge {
       clearTimeout(timeoutId);
       if (idleTimerId) clearTimeout(idleTimerId);
       try { executionHandle.finish(); } catch (e) { this.logger.warn({ err: e, chatId }, 'Error finishing execution handle'); }
+      try { detachApprovals?.(); } catch (e) { this.logger.warn({ err: e, chatId }, 'Error detaching approval bridge'); }
       this.runningTasks.delete(chatId);
       metrics.setGauge('metabot_active_tasks', this.runningTasks.size);
       this.processQueue(chatId);

--- a/src/bridge/message-sender.interface.ts
+++ b/src/bridge/message-sender.interface.ts
@@ -37,6 +37,22 @@ export interface IMessageSender {
   /** Download a user-sent file to a local path. */
   downloadFile(messageId: string, fileKey: string, savePath: string): Promise<boolean>;
 
+  /**
+   * Send a raw platform-native card payload (e.g. Feishu 2.0 card JSON).
+   * Used for special-purpose cards that don't fit the CardState schema —
+   * currently the dangerous-command approval card (see
+   * `src/security/approval-card.ts`). Returns `undefined` on platforms that
+   * don't support raw cards; the caller must degrade gracefully (e.g. fall
+   * back to `sendTextNotice`).
+   */
+  sendRawCard?(chatId: string, cardJson: string): Promise<string | undefined>;
+
+  /**
+   * Update an existing raw card. Returns `false` on platforms that don't
+   * support raw cards OR on transport failure.
+   */
+  updateRawCard?(messageId: string, cardJson: string): Promise<boolean>;
+
   /** If true, the bridge will not send a separate "Task completed" text after the card update. */
   skipCompletionNotice?: boolean;
 }

--- a/src/claude/executor.ts
+++ b/src/claude/executor.ts
@@ -118,6 +118,15 @@ export interface ExecutorOptions {
   model?: string;
   /** Override allowed tools for this execution (empty array = no tools). */
   allowedTools?: string[];
+
+  /**
+   * Optional pre-execution approval check for Bash tool calls. Called for
+   * every Bash invocation with the candidate command string; returns
+   * `'allow'` to proceed or `'deny'` to block. Absent = no approval layer
+   * (legacy behavior). Wired by `MessageBridge` to the dangerous-command
+   * approval system (see `src/security/approval-store.ts`).
+   */
+  approvalHandler?: (command: string) => Promise<'allow' | 'deny'>;
 }
 
 export type SDKMessage = {
@@ -407,11 +416,55 @@ export class ClaudeExecutor {
       };
     };
 
+    // Bash approval hook: if the caller registered an approvalHandler, run
+    // every Bash command through it before execution. The handler returns
+    // 'allow' / 'deny'; deny → block via the SDK's permission-decision path.
+    const bashApprovalHook = async (
+      input: { hook_event_name: string; tool_name: string; tool_input: unknown },
+    ): Promise<Record<string, unknown>> => {
+      if (!options.approvalHandler) {
+        return { hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } };
+      }
+      const toolInput = input.tool_input as { command?: string } | undefined;
+      const command = typeof toolInput?.command === 'string' ? toolInput.command : '';
+      if (!command) {
+        return { hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } };
+      }
+      try {
+        const verdict = await options.approvalHandler(command);
+        if (verdict === 'deny') {
+          return {
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'deny',
+              permissionDecisionReason:
+                '用户已拒绝此危险命令（或会话被终止）。不要再重试同一命令 — 请询问用户或尝试不同方案。',
+            },
+          };
+        }
+        return {
+          hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' },
+        };
+      } catch (err) {
+        this.logger.error(
+          { err: (err as Error).message, command: command.slice(0, 200) },
+          'bashApprovalHook threw — failing closed (deny)',
+        );
+        return {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason: '审批系统错误，已阻断该命令 — 请稍后重试。',
+          },
+        };
+      }
+    };
+
     queryOptions.hooks = {
-      PreToolUse: [{
-        matcher: 'AskUserQuestion',
-        hooks: [askUserQuestionHook as any],
-      }],
+      PreToolUse: [
+        { matcher: 'AskUserQuestion', hooks: [askUserQuestionHook as any] },
+        { matcher: 'Bash', hooks: [bashApprovalHook as any] },
+      ],
     };
 
     const stream = query({

--- a/src/feishu/feishu-sender-adapter.ts
+++ b/src/feishu/feishu-sender-adapter.ts
@@ -20,6 +20,16 @@ export class FeishuSenderAdapter implements IMessageSender {
     return this.sender.updateCard(messageId, buildCard(state));
   }
 
+  /** Send a raw Feishu card JSON payload (used for the approval card). */
+  async sendRawCard(chatId: string, cardJson: string): Promise<string | undefined> {
+    return this.sender.sendCard(chatId, cardJson);
+  }
+
+  /** Update an existing raw Feishu card JSON payload. */
+  async updateRawCard(messageId: string, cardJson: string): Promise<boolean> {
+    return this.sender.updateCard(messageId, cardJson);
+  }
+
   async sendTextNotice(chatId: string, title: string, content: string, color: string = 'blue'): Promise<void> {
     await this.sender.sendCard(chatId, buildTextCard(title, content, color));
   }

--- a/src/security/approval-bridge.ts
+++ b/src/security/approval-bridge.ts
@@ -1,0 +1,227 @@
+/**
+ * Bridge between `ApprovalStore` and the Feishu message sender.
+ *
+ * Responsibilities:
+ *   - On `ApprovalStore.promptApproval`, send a pending card and remember
+ *     the `(approvalId → messageId)` mapping.
+ *   - On button click / `/approve` / `/deny` / timeout, update the pending
+ *     card to the resolved green/red state.
+ *   - Offer a small façade (`handleButtonClick`, `resolveText`, `attachToTask`)
+ *     that `MessageBridge` can use without needing to know the store's API.
+ *
+ * The module is intentionally **decoupled from the Feishu SDK** — it depends
+ * on a `CardSender` interface, which `message-bridge` wires up using its
+ * existing `MessageSender`. This keeps the file testable with a plain mock.
+ */
+
+import { ApprovalStore, type ApprovalChoice, type ApprovalRequest } from './approval-store.js';
+import {
+  APPROVAL_BUTTON_KIND,
+  buildPendingApprovalCard,
+  buildResolvedApprovalCard,
+} from './approval-card.js';
+
+/**
+ * Minimal card-sender surface. Matches the subset of `IMessageSender`
+ * (`sendRawCard` / `updateRawCard`) used for approval UI — implemented by
+ * `FeishuSenderAdapter` and any other platform that supports raw cards.
+ */
+export interface CardSender {
+  sendCard(chatId: string, cardContent: string): Promise<string | undefined>;
+  updateCard(messageId: string, cardContent: string): Promise<boolean>;
+}
+
+/** Structured error logger — pino's `.error(obj, msg)` shape is compatible. */
+export interface Logger {
+  info(obj: Record<string, unknown>, msg?: string): void;
+  warn(obj: Record<string, unknown>, msg?: string): void;
+  error(obj: Record<string, unknown>, msg?: string): void;
+}
+
+/**
+ * Payload shape of the button's `value` field. `MessageBridge.handleCardAction`
+ * decodes this once it sees `kind === APPROVAL_BUTTON_KIND`.
+ */
+export interface ApprovalButtonValue {
+  kind: typeof APPROVAL_BUTTON_KIND;
+  approvalId: string;
+  choice: ApprovalChoice;
+}
+
+interface InflightApproval {
+  chatId: string;
+  messageId?: string;
+  request: ApprovalRequest;
+  resolved: boolean;
+}
+
+export class ApprovalBridge {
+  /** approvalId → inflight state (so button clicks can find the card messageId). */
+  private readonly inflight = new Map<string, InflightApproval>();
+
+  constructor(
+    private readonly store: ApprovalStore,
+    private readonly sender: CardSender,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Bind this bridge to a chat session. The returned `detach()` cleans up the
+   * notify callback and denies any pending approvals so the Promise layer
+   * doesn't leak. Call this at task start, call the returned fn at task end.
+   */
+  attachToSession(chatId: string): () => void {
+    this.store.registerNotify(chatId, (approvalId, request) => {
+      const entry: InflightApproval = { chatId, request, resolved: false };
+      this.inflight.set(approvalId, entry);
+
+      // Attach a settlement observer so out-of-band resolutions (timeout,
+      // `unregisterNotify` on detach, or any store-internal path) also
+      // refresh the Feishu card. Button clicks and text commands go
+      // through `this.resolve()` which sets `entry.resolved = true` before
+      // calling `store.resolveById`, so this observer no-ops for those —
+      // avoiding a double card update.
+      this.store.onSettle(approvalId, (choice) => {
+        this.handleAutoSettle(approvalId, choice);
+      });
+
+      const card = buildPendingApprovalCard({ approvalId, request });
+      // sendCard is async — we do NOT await it in the notify cb (the cb is
+      // sync-ish). If the send fails, we surface via onError and auto-deny
+      // so the agent doesn't wait on a message the user will never see.
+      this.sender
+        .sendCard(chatId, card)
+        .then((messageId) => {
+          const current = this.inflight.get(approvalId);
+          if (!current || current.resolved) return;
+          current.messageId = messageId;
+        })
+        .catch((err) => {
+          this.logger.error(
+            { approvalId, chatId, err: (err as Error).message },
+            'approval card send failed — auto-denying',
+          );
+          this.inflight.delete(approvalId);
+          this.store.resolveById(approvalId, 'deny');
+        });
+    });
+
+    return () => {
+      this.store.unregisterNotify(chatId);
+      // Clean up any inflight entries for this chat to prevent unbounded growth.
+      for (const [id, entry] of this.inflight) {
+        if (entry.chatId === chatId) this.inflight.delete(id);
+      }
+    };
+  }
+
+  /**
+   * Handle a card button click. Returns `true` if the value belongs to this
+   * bridge and was routed; `false` otherwise (so the caller can try the next
+   * handler).
+   */
+  handleButtonClick(value: unknown, operator?: string): boolean {
+    if (!isApprovalValue(value)) return false;
+    this.resolve(value.approvalId, value.choice, operator, false);
+    return true;
+  }
+
+  /**
+   * Handle `/approve` / `/deny` text commands. Resolves the oldest pending
+   * approval in the given session. Returns the number of approvals resolved.
+   */
+  resolveNextByText(chatId: string, choice: ApprovalChoice, operator?: string): number {
+    // Find the oldest inflight for this chat.
+    const entry = [...this.inflight.entries()].find(
+      ([, e]) => e.chatId === chatId && !e.resolved,
+    );
+    if (!entry) return 0;
+    this.resolve(entry[0], choice, operator, false);
+    return 1;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  /**
+   * Handle a settlement that did NOT originate from a user button/text
+   * action — i.e. store-driven resolution (timeout) or bridge-driven teardown
+   * (`unregisterNotify` inside detach). If the inflight entry is still
+   * unresolved, we render the resolved card marked `autoResolved: true` so
+   * the operator can see the reason.
+   */
+  private handleAutoSettle(approvalId: string, choice: ApprovalChoice): void {
+    const entry = this.inflight.get(approvalId);
+    if (!entry || entry.resolved) return;
+    entry.resolved = true;
+
+    if (entry.messageId) {
+      const card = buildResolvedApprovalCard({
+        approvalId,
+        request: entry.request,
+        choice,
+        autoResolved: true,
+      });
+      this.sender.updateCard(entry.messageId, card).catch((err) => {
+        this.logger.error(
+          { approvalId, messageId: entry.messageId, err: (err as Error).message },
+          'failed to update auto-resolved approval card',
+        );
+      });
+    }
+    this.inflight.delete(approvalId);
+  }
+
+  private resolve(
+    approvalId: string,
+    choice: ApprovalChoice,
+    operator: string | undefined,
+    autoResolved: boolean,
+  ): void {
+    const entry = this.inflight.get(approvalId);
+    if (!entry || entry.resolved) return;
+    entry.resolved = true;
+
+    const ok = this.store.resolveById(approvalId, choice);
+    if (!ok) {
+      // Store had already resolved this (timeout / clearSession) — still update UI.
+      this.logger.warn(
+        { approvalId, chatId: entry.chatId, choice },
+        'approval resolveById returned false (already resolved upstream)',
+      );
+    }
+
+    // Re-render the card in resolved state. Skip if we never got a messageId
+    // (sendCard hadn't completed by the time of resolution — rare).
+    if (entry.messageId) {
+      const card = buildResolvedApprovalCard({
+        approvalId,
+        request: entry.request,
+        choice,
+        operator,
+        autoResolved,
+      });
+      this.sender.updateCard(entry.messageId, card).catch((err) => {
+        this.logger.error(
+          { approvalId, messageId: entry.messageId, err: (err as Error).message },
+          'failed to update resolved approval card',
+        );
+      });
+    }
+
+    this.inflight.delete(approvalId);
+  }
+}
+
+/** Type guard for the button `value` payload. */
+export function isApprovalValue(value: unknown): value is ApprovalButtonValue {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.kind === APPROVAL_BUTTON_KIND &&
+    typeof v.approvalId === 'string' &&
+    typeof v.choice === 'string' &&
+    ['once', 'session', 'always', 'deny'].includes(v.choice as string)
+  );
+}

--- a/src/security/approval-card.ts
+++ b/src/security/approval-card.ts
@@ -1,0 +1,164 @@
+/**
+ * Feishu interactive cards for dangerous-command approval.
+ *
+ * Three states — all produced as plain JSON strings ready for
+ * `messageSender.sendCard` / `updateCard`:
+ *
+ *   1. `buildPendingApprovalCard`   — orange header + 4 buttons (Once / Session
+ *                                     / Always / Deny). Sent when the engine
+ *                                     first prompts the user.
+ *   2. `buildResolvedApprovalCard`  — green header ("✅ Allowed") or red header
+ *                                     ("🚫 Denied"), operator + timestamp, no
+ *                                     buttons. Replaces the pending card.
+ *
+ * The card visual language (orange/green/red) mirrors Hermes's
+ * `send_exec_approval` in `gateway/platforms/feishu.py`.
+ *
+ * Buttons carry `value: { kind: 'dangerous_approval', approvalId, choice }`
+ * so `MessageBridge.handleCardAction` can route clicks back to
+ * `approvalStore.resolveById`.
+ */
+
+import type { ApprovalChoice, ApprovalRequest } from './approval-store.js';
+
+/** Kind tag for the Feishu button `value` — matched in `handleCardAction`. */
+export const APPROVAL_BUTTON_KIND = 'dangerous_approval';
+
+/** Map choice → button label + type (Feishu's built-in button styles). */
+const BUTTON_SPEC: Array<{ choice: ApprovalChoice; label: string; type: string }> = [
+  { choice: 'once', label: '✅ 仅本次', type: 'primary' },
+  { choice: 'session', label: '✅ 本会话', type: 'primary' },
+  { choice: 'always', label: '✅ 永久允许', type: 'primary' },
+  { choice: 'deny', label: '🚫 拒绝', type: 'danger' },
+];
+
+/** Truncate a command preview so long heredocs / inline scripts don't blow up the card. */
+const MAX_COMMAND_PREVIEW = 1500;
+function previewCommand(cmd: string): string {
+  if (cmd.length <= MAX_COMMAND_PREVIEW) return cmd;
+  return cmd.slice(0, MAX_COMMAND_PREVIEW) + `\n… (truncated, ${cmd.length - MAX_COMMAND_PREVIEW} more chars)`;
+}
+
+function escapeBackticks(s: string): string {
+  return s.replace(/`/g, '\\`');
+}
+
+export interface PendingApprovalCardInput {
+  approvalId: string;
+  request: ApprovalRequest;
+}
+
+/**
+ * Build the orange "awaiting approval" card.
+ */
+export function buildPendingApprovalCard(input: PendingApprovalCardInput): string {
+  const { approvalId, request } = input;
+  const cmdPreview = previewCommand(request.command);
+
+  const card = {
+    schema: '2.0',
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: '⚠️ 危险命令需要确认' },
+      template: 'orange',
+    },
+    body: {
+      elements: [
+        {
+          tag: 'markdown',
+          content:
+            `**匹配规则：** ${request.description}\n\n` +
+            `**命令：**\n\`\`\`bash\n${escapeBackticks(cmdPreview)}\n\`\`\``,
+        },
+        { tag: 'hr' },
+        {
+          tag: 'action',
+          layout: 'flow',
+          actions: BUTTON_SPEC.map(({ choice, label, type }) => ({
+            tag: 'button',
+            text: { tag: 'plain_text', content: label },
+            type,
+            value: {
+              kind: APPROVAL_BUTTON_KIND,
+              approvalId,
+              choice,
+            },
+          })),
+        },
+        {
+          tag: 'markdown',
+          content:
+            '_一次（Once）：仅本次放行_ · _本会话（Session）：匹配同一规则不再弹窗_ · ' +
+            '_永久（Always）：跨会话保存_ · _拒绝（Deny）：阻断执行_',
+        },
+      ],
+    },
+  };
+  return JSON.stringify(card);
+}
+
+export interface ResolvedApprovalCardInput {
+  approvalId: string;
+  request: ApprovalRequest;
+  choice: ApprovalChoice;
+  /** User ID / name that resolved this approval. Shown in the footer. */
+  operator?: string;
+  /** Resolution timestamp (ms since epoch). Defaults to `Date.now()`. */
+  resolvedAt?: number;
+  /** Set to true when the timeout auto-denied (vs a user click). */
+  autoResolved?: boolean;
+}
+
+const CHOICE_HEADERS: Record<ApprovalChoice, { title: string; template: string }> = {
+  once: { title: '✅ 已允许（仅本次）', template: 'green' },
+  session: { title: '✅ 已允许（本会话）', template: 'green' },
+  always: { title: '✅ 已永久允许', template: 'green' },
+  deny: { title: '🚫 已拒绝', template: 'red' },
+};
+
+/**
+ * Build the green/red "resolved" card that replaces the pending one after a
+ * button click, `/approve`, `/deny`, or a fail-closed auto-deny.
+ */
+export function buildResolvedApprovalCard(input: ResolvedApprovalCardInput): string {
+  const {
+    approvalId,
+    request,
+    choice,
+    operator,
+    resolvedAt = Date.now(),
+    autoResolved = false,
+  } = input;
+
+  const { title, template } = CHOICE_HEADERS[choice];
+  const cmdPreview = previewCommand(request.command);
+
+  const footerLines = [
+    operator ? `**操作人：** ${operator}` : null,
+    `**时间：** ${new Date(resolvedAt).toISOString()}`,
+    autoResolved ? '_（超时自动处理）_' : null,
+    `_approval id: ${approvalId}_`,
+  ].filter(Boolean);
+
+  const card = {
+    schema: '2.0',
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: title },
+      template,
+    },
+    body: {
+      elements: [
+        {
+          tag: 'markdown',
+          content:
+            `**匹配规则：** ${request.description}\n\n` +
+            `**命令：**\n\`\`\`bash\n${escapeBackticks(cmdPreview)}\n\`\`\``,
+        },
+        { tag: 'hr' },
+        { tag: 'markdown', content: footerLines.join('\n') },
+      ],
+    },
+  };
+  return JSON.stringify(card);
+}

--- a/src/security/approval-store.ts
+++ b/src/security/approval-store.ts
@@ -88,6 +88,14 @@ interface PendingEntry {
   settled: boolean;
   /** Set if a timeout is armed — cleared on resolution. */
   timeoutHandle?: ReturnType<typeof setTimeout>;
+  /**
+   * Optional per-entry settlement observer. Invoked for every resolution path
+   * (user click via `resolveById`, text command via `resolveNext`, timeout,
+   * `unregisterNotify`). Consumers that need to react to out-of-band
+   * settlements (e.g. the bridge updating a stale pending card to its
+   * resolved state) register a callback via `onSettle(approvalId, cb)`.
+   */
+  onSettle?: (choice: ApprovalChoice) => void;
 }
 
 export class ApprovalStore {
@@ -239,6 +247,16 @@ export class ApprovalStore {
           entry.settled = true;
           if (entry.timeoutHandle) clearTimeout(entry.timeoutHandle);
           this.byId.delete(id);
+          // Fire the per-entry observer (if any) before resolving the outer
+          // Promise, so UI-layer state (e.g. the bridge's resolved card)
+          // settles in lockstep with the agent's view. Observer errors must
+          // not block the caller's Promise.
+          const observer = entry.onSettle;
+          if (observer) {
+            try { observer(choice); } catch (err) {
+              this.onError('onSettle observer threw', err);
+            }
+          }
           resolve(choice);
         },
         createdAt: Date.now(),
@@ -351,6 +369,24 @@ export class ApprovalStore {
       entry.resolve(choice);
     }
     return entries.length;
+  }
+
+  /**
+   * Register a settlement observer for a specific pending approval. The
+   * callback runs on every resolution path — button click, text command,
+   * timeout, `unregisterNotify`. Returns `true` if the entry was found and
+   * the observer attached, `false` if the id is unknown (already settled
+   * or never existed).
+   *
+   * The bridge uses this to update the pending Feishu card to a
+   * green/red resolved state whenever the underlying approval settles, so
+   * the UI never shows orange after the agent has moved on.
+   */
+  onSettle(approvalId: string, cb: (choice: ApprovalChoice) => void): boolean {
+    const entry = this.byId.get(approvalId);
+    if (!entry || entry.settled) return false;
+    entry.onSettle = cb;
+    return true;
   }
 
   /**

--- a/tests/approval-bridge.test.ts
+++ b/tests/approval-bridge.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApprovalStore } from '../src/security/approval-store.js';
+import {
+  ApprovalBridge,
+  isApprovalValue,
+  type CardSender,
+  type Logger,
+} from '../src/security/approval-bridge.js';
+import { APPROVAL_BUTTON_KIND } from '../src/security/approval-card.js';
+
+const CHAT = 'oc_chat_A';
+const REQ = { command: 'rm -rf /tmp/foo', description: 'recursive delete', patternKey: 'recursive delete' };
+
+function makeSender(): CardSender & {
+  sendCard: ReturnType<typeof vi.fn>;
+  updateCard: ReturnType<typeof vi.fn>;
+} {
+  return {
+    sendCard: vi.fn<CardSender['sendCard']>().mockResolvedValue('msg_1'),
+    updateCard: vi.fn<CardSender['updateCard']>().mockResolvedValue(true),
+  };
+}
+
+function makeLogger(): Logger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('isApprovalValue', () => {
+  it('accepts well-formed approval values', () => {
+    expect(
+      isApprovalValue({
+        kind: APPROVAL_BUTTON_KIND,
+        approvalId: 'x',
+        choice: 'once',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects wrong kind', () => {
+    expect(
+      isApprovalValue({ kind: 'askuser_answer', approvalId: 'x', choice: 'once' }),
+    ).toBe(false);
+  });
+
+  it('rejects invalid choice', () => {
+    expect(
+      isApprovalValue({ kind: APPROVAL_BUTTON_KIND, approvalId: 'x', choice: 'maybe' }),
+    ).toBe(false);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isApprovalValue(null)).toBe(false);
+    expect(isApprovalValue('string')).toBe(false);
+    expect(isApprovalValue(42)).toBe(false);
+  });
+});
+
+describe('ApprovalBridge — notify → sendCard → button click → updateCard', () => {
+  it('sends a pending card on prompt, updates to resolved on button click', async () => {
+    const store = new ApprovalStore();
+    const sender = makeSender();
+    const bridge = new ApprovalBridge(store, sender, makeLogger());
+    const detach = bridge.attachToSession(CHAT);
+
+    const p = store.promptApproval(CHAT, REQ);
+    // Drain the notify microtask + the sendCard Promise.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sender.sendCard).toHaveBeenCalledTimes(1);
+    const [, cardJson] = sender.sendCard.mock.calls[0] as [string, string];
+    const card = JSON.parse(cardJson);
+    // Find the approvalId from the button value for the click we're about to simulate.
+    const action = card.body.elements.find((e: any) => e.tag === 'action');
+    const oneBtn = action.actions.find((b: any) => b.value.choice === 'once');
+    expect(oneBtn.value.kind).toBe(APPROVAL_BUTTON_KIND);
+
+    const routed = bridge.handleButtonClick(oneBtn.value, 'user_xyz');
+    expect(routed).toBe(true);
+
+    await expect(p).resolves.toBe('once');
+    expect(sender.updateCard).toHaveBeenCalledTimes(1);
+    const updateCardJson = sender.updateCard.mock.calls[0][1] as string;
+    expect(updateCardJson).toContain('user_xyz');
+    expect(JSON.parse(updateCardJson).header.template).toBe('green');
+
+    detach();
+  });
+
+  it('deny click produces a red resolved card and the promise resolves to deny', async () => {
+    const store = new ApprovalStore();
+    const sender = makeSender();
+    const bridge = new ApprovalBridge(store, sender, makeLogger());
+    bridge.attachToSession(CHAT);
+
+    const p = store.promptApproval(CHAT, REQ);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const card = JSON.parse(sender.sendCard.mock.calls[0][1] as string);
+    const denyBtn = card.body.elements
+      .find((e: any) => e.tag === 'action')
+      .actions.find((b: any) => b.value.choice === 'deny');
+    bridge.handleButtonClick(denyBtn.value, 'user_xyz');
+
+    await expect(p).resolves.toBe('deny');
+    const updateJson = sender.updateCard.mock.calls[0][1] as string;
+    expect(JSON.parse(updateJson).header.template).toBe('red');
+  });
+
+  it('handleButtonClick returns false for non-approval values (delegates elsewhere)', () => {
+    const store = new ApprovalStore();
+    const bridge = new ApprovalBridge(store, makeSender(), makeLogger());
+    expect(bridge.handleButtonClick({ kind: 'askuser_answer' })).toBe(false);
+    expect(bridge.handleButtonClick(null)).toBe(false);
+  });
+
+  it('handleButtonClick is idempotent — second click on same approvalId is a no-op', async () => {
+    const store = new ApprovalStore();
+    const sender = makeSender();
+    const bridge = new ApprovalBridge(store, sender, makeLogger());
+    bridge.attachToSession(CHAT);
+
+    const p = store.promptApproval(CHAT, REQ);
+    await Promise.resolve();
+    await Promise.resolve();
+    const card = JSON.parse(sender.sendCard.mock.calls[0][1] as string);
+    const btn = card.body.elements.find((e: any) => e.tag === 'action').actions[0].value;
+
+    bridge.handleButtonClick(btn);
+    bridge.handleButtonClick(btn); // duplicate
+    await p;
+
+    expect(sender.updateCard).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ApprovalBridge — resolveNextByText (/approve /deny commands)', () => {
+  it('resolves the oldest pending approval for the chat', async () => {
+    const store = new ApprovalStore();
+    const sender = makeSender();
+    const bridge = new ApprovalBridge(store, sender, makeLogger());
+    bridge.attachToSession(CHAT);
+
+    const p1 = store.promptApproval(CHAT, REQ);
+    const p2 = store.promptApproval(CHAT, { ...REQ, command: 'rm -rf /tmp/bar' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const resolved = bridge.resolveNextByText(CHAT, 'session', 'cmd_user');
+    expect(resolved).toBe(1);
+    await expect(p1).resolves.toBe('session');
+    // p2 still pending
+    bridge.resolveNextByText(CHAT, 'deny', 'cmd_user');
+    await expect(p2).resolves.toBe('deny');
+  });
+
+  it('returns 0 when no pending approval exists', () => {
+    const store = new ApprovalStore();
+    const bridge = new ApprovalBridge(store, makeSender(), makeLogger());
+    bridge.attachToSession(CHAT);
+    expect(bridge.resolveNextByText(CHAT, 'once')).toBe(0);
+  });
+});
+
+describe('ApprovalBridge — failure & detach semantics', () => {
+  it('auto-denies when sendCard rejects', async () => {
+    const store = new ApprovalStore();
+    const sender = makeSender();
+    sender.sendCard.mockRejectedValueOnce(new Error('network'));
+    const logger = makeLogger();
+    const bridge = new ApprovalBridge(store, sender, logger);
+    bridge.attachToSession(CHAT);
+
+    const p = store.promptApproval(CHAT, REQ);
+    await expect(p).resolves.toBe('deny');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('detach() denies all in-flight approvals for the chat', async () => {
+    const store = new ApprovalStore();
+    const sender = makeSender();
+    const bridge = new ApprovalBridge(store, sender, makeLogger());
+    const detach = bridge.attachToSession(CHAT);
+
+    const p = store.promptApproval(CHAT, REQ);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    detach();
+    await expect(p).resolves.toBe('deny');
+  });
+
+  it('timeout auto-settles the card as resolved and ignores late clicks', async () => {
+    vi.useFakeTimers();
+    const store = new ApprovalStore({ timeoutMs: 5_000 });
+    const sender = makeSender();
+    const logger = makeLogger();
+    const bridge = new ApprovalBridge(store, sender, logger);
+    bridge.attachToSession(CHAT);
+
+    const p = store.promptApproval(CHAT, REQ);
+    await Promise.resolve();
+    await Promise.resolve();
+    const card = JSON.parse(sender.sendCard.mock.calls[0][1] as string);
+    const btn = card.body.elements.find((e: any) => e.tag === 'action').actions[0].value;
+
+    // Fire timeout — store resolves as deny, bridge observer updates the card.
+    vi.advanceTimersByTime(5_000);
+    await expect(p).resolves.toBe('deny');
+
+    // The card was rewritten to resolved state via the onSettle observer.
+    expect(sender.updateCard).toHaveBeenCalledTimes(1);
+    const updateJson = sender.updateCard.mock.calls[0][1] as string;
+    expect(JSON.parse(updateJson).header.template).toBe('red');
+
+    // Late click on a stale card must be a no-op — inflight already marked
+    // resolved, and the id is gone from the store.
+    bridge.handleButtonClick(btn);
+    expect(sender.updateCard).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it('detach auto-settles any in-flight cards before unregistering', async () => {
+    const store = new ApprovalStore();
+    const sender = makeSender();
+    const bridge = new ApprovalBridge(store, sender, makeLogger());
+    const detach = bridge.attachToSession(CHAT);
+
+    const p = store.promptApproval(CHAT, REQ);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(sender.sendCard).toHaveBeenCalledTimes(1);
+
+    detach();
+    await expect(p).resolves.toBe('deny');
+
+    expect(sender.updateCard).toHaveBeenCalledTimes(1);
+    const updateJson = sender.updateCard.mock.calls[0][1] as string;
+    expect(JSON.parse(updateJson).header.template).toBe('red');
+  });
+});

--- a/tests/approval-card.test.ts
+++ b/tests/approval-card.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  APPROVAL_BUTTON_KIND,
+  buildPendingApprovalCard,
+  buildResolvedApprovalCard,
+} from '../src/security/approval-card.js';
+
+const REQ = {
+  command: 'rm -rf /tmp/foo',
+  description: 'recursive delete',
+  patternKey: 'recursive delete',
+};
+
+function parseCard(json: string): any {
+  return JSON.parse(json);
+}
+
+describe('buildPendingApprovalCard', () => {
+  it('uses orange template for the "awaiting" state', () => {
+    const card = parseCard(buildPendingApprovalCard({ approvalId: 'a_1', request: REQ }));
+    expect(card.header.template).toBe('orange');
+    expect(card.header.title.content).toContain('危险命令');
+  });
+
+  it('embeds the matched pattern description and the command', () => {
+    const json = buildPendingApprovalCard({ approvalId: 'a_1', request: REQ });
+    expect(json).toContain('recursive delete');
+    expect(json).toContain('rm -rf /tmp/foo');
+  });
+
+  it('emits exactly 4 buttons in choice order: once, session, always, deny', () => {
+    const card = parseCard(buildPendingApprovalCard({ approvalId: 'a_1', request: REQ }));
+    const action = card.body.elements.find((e: any) => e.tag === 'action');
+    expect(action).toBeTruthy();
+    expect(action.actions).toHaveLength(4);
+    expect(action.actions.map((b: any) => b.value.choice)).toEqual([
+      'once',
+      'session',
+      'always',
+      'deny',
+    ]);
+  });
+
+  it('each button carries the APPROVAL_BUTTON_KIND tag + approvalId', () => {
+    const card = parseCard(buildPendingApprovalCard({ approvalId: 'a_42', request: REQ }));
+    const action = card.body.elements.find((e: any) => e.tag === 'action');
+    for (const btn of action.actions) {
+      expect(btn.value.kind).toBe(APPROVAL_BUTTON_KIND);
+      expect(btn.value.approvalId).toBe('a_42');
+    }
+  });
+
+  it('deny button uses "danger" style, others use "primary"', () => {
+    const card = parseCard(buildPendingApprovalCard({ approvalId: 'a_1', request: REQ }));
+    const action = card.body.elements.find((e: any) => e.tag === 'action');
+    const denyBtn = action.actions.find((b: any) => b.value.choice === 'deny');
+    const onceBtn = action.actions.find((b: any) => b.value.choice === 'once');
+    expect(denyBtn.type).toBe('danger');
+    expect(onceBtn.type).toBe('primary');
+  });
+
+  it('truncates extremely long commands', () => {
+    const longCmd = 'echo "' + 'A'.repeat(5000) + '"';
+    const json = buildPendingApprovalCard({
+      approvalId: 'a_1',
+      request: { ...REQ, command: longCmd },
+    });
+    expect(json).toContain('truncated');
+    // Card body should not contain the full 5000-char payload.
+    expect(json.length).toBeLessThan(longCmd.length + 2000);
+  });
+
+  it('escapes backticks in the command so the markdown fence survives', () => {
+    const cmd = 'echo `whoami`';
+    const json = buildPendingApprovalCard({
+      approvalId: 'a_1',
+      request: { ...REQ, command: cmd },
+    });
+    expect(json).toContain('\\\\`whoami\\\\`'); // JSON-escaped "\\`whoami\\`"
+  });
+});
+
+describe('buildResolvedApprovalCard', () => {
+  it('green template for "once"/"session"/"always", red for "deny"', () => {
+    for (const c of ['once', 'session', 'always'] as const) {
+      const card = parseCard(
+        buildResolvedApprovalCard({ approvalId: 'a_1', request: REQ, choice: c }),
+      );
+      expect(card.header.template).toBe('green');
+    }
+    const deny = parseCard(
+      buildResolvedApprovalCard({ approvalId: 'a_1', request: REQ, choice: 'deny' }),
+    );
+    expect(deny.header.template).toBe('red');
+  });
+
+  it('includes operator and resolvedAt timestamp in the footer', () => {
+    const at = Date.UTC(2026, 3, 17, 12, 0, 0);
+    const json = buildResolvedApprovalCard({
+      approvalId: 'a_1',
+      request: REQ,
+      choice: 'once',
+      operator: 'user_abc',
+      resolvedAt: at,
+    });
+    expect(json).toContain('user_abc');
+    expect(json).toContain(new Date(at).toISOString());
+  });
+
+  it('indicates autoResolved in the footer when set', () => {
+    const json = buildResolvedApprovalCard({
+      approvalId: 'a_1',
+      request: REQ,
+      choice: 'deny',
+      autoResolved: true,
+    });
+    expect(json).toContain('超时自动处理');
+  });
+
+  it('does NOT emit any button/action element (cannot be clicked again)', () => {
+    const card = parseCard(
+      buildResolvedApprovalCard({ approvalId: 'a_1', request: REQ, choice: 'once' }),
+    );
+    const action = card.body.elements.find((e: any) => e.tag === 'action');
+    expect(action).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Surface dangerous \`Bash\` commands in Feishu as an interactive approval card (orange → green/red) with once / session / always / deny buttons; fail-closed PreToolUse hook.
- Add \`/approve\`, \`/deny\`, \`/yolo [on|off]\` text commands; \`/reset\` now also clears chat approval state.
- Cross-platform safe: Telegram silently degrades (no \`sendRawCard\`/\`updateRawCard\`) — Bash still runs without prompts, exactly as pre-#14.

## What changed
**New**
- \`src/security/approval-card.ts\` — Feishu 2.0 card builders for pending & resolved states.
- \`src/security/approval-bridge.ts\` — glue between \`ApprovalStore\` and a platform-agnostic \`CardSender\`; handles button clicks, text commands, and out-of-band settlement observers.
- 24 new tests across \`tests/approval-card.test.ts\` and \`tests/approval-bridge.test.ts\`.

**Wiring**
- \`ClaudeExecutor\`: PreToolUse Bash hook calls \`options.approvalHandler\`; any throw → \`permissionDecision: 'deny'\`.
- \`MessageBridge\`: per-task attach/detach of the approval bridge + per-task \`approvalHandler\` that consults the pre-approval cache before prompting. \`handleCardAction\` routes approval buttons before \`askuser_answer\`.
- \`CommandHandler\`: \`/approve\`, \`/deny\`, \`/yolo [on|off]\`; \`/reset\` + \`freshSession\` now call \`approvalStore.clearSession\`.
- \`IMessageSender\`: optional \`sendRawCard\` / \`updateRawCard\` implemented by the Feishu adapter only.

## Codex review fixes rolled in
1. \`/reset\` + \`freshSession\` no longer leak YOLO / session allowlist.
2. Added \`ApprovalStore.onSettle(approvalId, cb)\` observer fired on every resolution path. The bridge subscribes in the notify callback and rewrites the pending card to a resolved state on timeout, detach, or any store-internal resolution. Button/text paths set \`entry.resolved = true\` before calling the store, so the observer is a no-op for user-driven settlements (no double update).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean on all touched files
- [x] \`npm test\` — 387 pass (25 test files)
- [ ] Manual smoke: deploy → try \`rm -rf /tmp/foo\` → verify orange card → click once → green card + command executes
- [ ] Manual smoke: \`/yolo on\` → dangerous command auto-approves; \`/yolo off\` → prompts again
- [ ] Manual smoke: \`/reset\` clears YOLO state

## Base branch
Depends on \`feat/approval-engine\` (Phase 2). Merge that first, or merge after rebasing on \`main\` once Phase 1+2 land.

Refs #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)