### PR TITLE
fix: include tool outputs and turn text in ApiTaskResult.responseText

### DIFF
--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -1708,12 +1708,19 @@ export class MessageBridge {
       metrics.observeHistogram('metabot_task_duration_seconds', durationMs / 1000);
       if (lastState.costUsd) metrics.observeHistogram('metabot_task_cost_usd', lastState.costUsd);
 
+      // Use the full session transcript (turns + tool outputs + result) for the
+      // bus reply, falling back to the live responseText if the session ended
+      // before any content was captured. Without this, sessions that end on
+      // tool calls return an empty responseText even though the chat shows the
+      // full conversation.
+      const fullResponseText = processor.getFullTranscript() || lastState.responseText;
+
       // Record in cross-platform session registry
-      this.recordSession(chatId, prompt, lastState.responseText, processor.getSessionId(), lastState.costUsd, durationMs);
+      this.recordSession(chatId, prompt, fullResponseText, processor.getSessionId(), lastState.costUsd, durationMs);
 
       return {
         success: lastState.status === 'complete',
-        responseText: lastState.responseText,
+        responseText: fullResponseText,
         sessionId: processor.getSessionId(),
         costUsd: lastState.costUsd,
         durationMs: lastState.durationMs,
@@ -1786,7 +1793,7 @@ export class MessageBridge {
 
           return {
             success: lastState.status === 'complete',
-            responseText: lastState.responseText,
+            responseText: processor.getFullTranscript() || lastState.responseText,
             sessionId: processor.getSessionId(),
             costUsd: lastState.costUsd,
             durationMs: lastState.durationMs,
@@ -1829,7 +1836,7 @@ export class MessageBridge {
 
       return {
         success: false,
-        responseText: lastState.responseText,
+        responseText: processor.getFullTranscript() || lastState.responseText,
         error: err.message || 'Unknown error',
       };
     } finally {

--- a/src/claude/stream-processor.ts
+++ b/src/claude/stream-processor.ts
@@ -33,6 +33,14 @@ export class StreamProcessor {
   private _lastSentTurnText: string | undefined;
   /** SDK result text, stored separately so it doesn't overwrite responseText */
   private _resultSummary: string | undefined;
+  /**
+   * Running transcript of everything that surfaces in the chat: assistant turn
+   * text, top-level tool outputs, and the SDK result summary. The bridge uses
+   * this for ApiTaskResult.responseText so synchronous bus callers see what the
+   * group chat sees — otherwise responseText is empty whenever the session
+   * ends on tool calls (no trailing assistant text).
+   */
+  private _transcript: string[] = [];
   private toolCalls: ToolCall[] = [];
   private toolSummaries: string[] = [];
   private subagentTasks: Map<string, SubagentTask> = new Map();
@@ -174,6 +182,7 @@ export class StreamProcessor {
         this._completedTurnText = block.text;
         this._lastSentTurnText = block.text;
         this.responseText = '';
+        this._transcript.push(block.text);
       } else if (block.type === 'tool_use' && block.name) {
         this.addToolCall(block.name, block.input);
         if (block.name === 'AskUserQuestion' && block.id && block.input) {
@@ -405,6 +414,9 @@ export class StreamProcessor {
     // Store result separately — only if it differs from the last turn text already sent.
     // SDK result often echoes the last assistant message; skip to avoid duplication.
     this._resultSummary = (resultText && resultText !== this._lastSentTurnText) ? resultText : undefined;
+    if (this._resultSummary && !isApiError) {
+      this._transcript.push(`[Result]\n${this._resultSummary}`);
+    }
 
     return {
       status: (isError || isApiError) ? 'error' : 'complete',
@@ -462,6 +474,8 @@ export class StreamProcessor {
         tool.status = 'done';
         if (output) {
           tool.output = output;
+          const header = tool.detail ? `[Tool: ${tool.name}] ${tool.detail}` : `[Tool: ${tool.name}]`;
+          this._transcript.push(`${header}\n${output}`);
         }
       }
       this.currentToolName = null;
@@ -543,6 +557,20 @@ export class StreamProcessor {
 
   getSessionId(): string | undefined {
     return this.sessionId;
+  }
+
+  /**
+   * Full transcript of the session as the chat saw it: each completed turn's
+   * text, each top-level tool output (with a `[Tool: Name] detail` header),
+   * the SDK result summary, and any in-progress text not yet flushed as a
+   * completed turn. Joined with blank lines. Used by the bridge to populate
+   * ApiTaskResult.responseText so sync bus callers receive the same content
+   * the Feishu cards show.
+   */
+  getFullTranscript(): string {
+    const parts = [...this._transcript];
+    if (this.responseText) parts.push(this.responseText);
+    return parts.join('\n\n').trim();
   }
 
   getImagePaths(): string[] {

--- a/tests/stream-processor.test.ts
+++ b/tests/stream-processor.test.ts
@@ -285,6 +285,73 @@ describe('StreamProcessor', () => {
     expect(p.drainSdkHandledTools()).toHaveLength(0);
   });
 
+  it('getFullTranscript captures turns, tool outputs, and result', () => {
+    const p = new StreamProcessor('do thing');
+    // Assistant turn with text + tool_use + tool_result
+    p.processMessage(msg({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: {
+        content: [
+          { type: 'text', text: 'Running the command now.' },
+          { type: 'tool_use', id: 'tool-1', name: 'Bash', input: { command: 'echo hi' } },
+        ],
+      },
+    }));
+    p.processMessage(msg({
+      type: 'user',
+      parent_tool_use_id: null,
+      message: { content: [{ type: 'tool_result', content: 'hi\n' }] },
+    }));
+    p.processMessage(msg({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: { content: [{ type: 'text', text: 'Done.' }] },
+    }));
+    p.processMessage(msg({
+      type: 'result',
+      subtype: 'success',
+      result: 'Task complete — 1 command run.',
+    }));
+
+    const transcript = p.getFullTranscript();
+    expect(transcript).toContain('Running the command now.');
+    expect(transcript).toContain('[Tool: Bash]');
+    expect(transcript).toContain('hi\n');
+    expect(transcript).toContain('Done.');
+    expect(transcript).toContain('[Result]');
+    expect(transcript).toContain('Task complete — 1 command run.');
+  });
+
+  it('getFullTranscript returns empty when no content captured', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({ type: 'system', session_id: 'sess' }));
+    expect(p.getFullTranscript()).toBe('');
+  });
+
+  it('getFullTranscript includes in-progress streaming text not yet flushed as a turn', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'stream_event',
+      parent_tool_use_id: null,
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Partial output' } },
+    }));
+    expect(p.getFullTranscript()).toBe('Partial output');
+  });
+
+  it('getFullTranscript omits result summary when it duplicates last turn text', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: { content: [{ type: 'text', text: 'The answer is 42.' }] },
+    }));
+    p.processMessage(msg({ type: 'result', subtype: 'success', result: 'The answer is 42.' }));
+    const transcript = p.getFullTranscript();
+    expect(transcript).toBe('The answer is 42.');
+    expect(transcript).not.toContain('[Result]');
+  });
+
   it('marks all tools as done on result', () => {
     const p = new StreamProcessor('hi');
     p.processMessage(msg({


### PR DESCRIPTION
Closes #26

## Summary
- Sync bus callers (\`mb task <bot> <chatId> \"...\"\`) get \`{success:true, responseText:\"\"}\` whenever the receiver ends its session on tool calls instead of trailing assistant text — because \`processResultMessage\` hard-codes \`responseText:''\` and per-turn text is cleared from \`responseText\` after each turn.
- This PR has \`StreamProcessor\` accumulate a transcript (turn text + top-level tool outputs + SDK result summary), exposed as \`getFullTranscript()\`. \`executeApiTask\` prefers that transcript for \`ApiTaskResult.responseText\` in all three return paths (success, stale-session retry success, catch error).
- Card rendering is untouched — \`CardState.responseText\` still drives live updates and the existing \`resultSummary\` / \`completedTurnText\` flow still feeds turn cards and the final Result card.

## Format
The transcript joins entries with blank lines:
\`\`\`
<turn 1 text>

[Tool: Bash] \`echo hi\`
hi

<turn 2 text>

[Result]
<SDK summary>
\`\`\`
The SDK-result dedup against last turn text (already in \`processResultMessage\`) is honored, so the result section is omitted when it would just echo the last turn.

## Test plan
- [x] \`npx vitest run tests/stream-processor.test.ts\` — 27/27 (4 new tests cover transcript assembly, empty session, in-progress text, dedup)
- [x] \`npx vitest run\` — 671/671
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: \`mb task manager <managerGroupChatId> \"echo hello\"\` returns a non-empty \`responseText\` containing tool calls + turn text

🤖 Generated with [Claude Code](https://claude.com/claude-code)