### PR TITLE
Batch 4: upstream Codex engine + resume fix (#214, #215, #219, #237)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,13 +211,29 @@ Knowledge persistence is handled by an external **MetaMemory server** (FastAPI +
 Before running the service, ensure:
 
 1. **Node.js 20+** is installed.
-2. **Claude Code CLI is installed and authenticated** — The Agent SDK spawns `claude` as a subprocess; it must be able to run independently.
+2. **At least one engine CLI is installed and authenticated** — MetaBot spawns the selected engine's CLI as a subprocess. Install only the engine(s) you intend to use; each bot picks one via `engine` in its config.
+
+   **Claude Code (default)** — `engine: "claude"`
    - Install: `npm install -g @anthropic-ai/claude-code`
    - Authenticate (one of):
      - **OAuth login (recommended)**: Run `claude login` in a standalone terminal and complete the browser flow.
      - **API Key**: Set `ANTHROPIC_API_KEY=sk-ant-...` in `.env` or your shell environment.
-   - Verify: Run `claude --version` and `claude "hello"` in a standalone terminal to confirm it works.
+   - Verify: Run `claude --version` and `claude "hello"` in a standalone terminal.
    - **Important**: You cannot run `claude login` or `claude auth status` from inside a Claude Code session (nested sessions are blocked). Always use a separate terminal.
+
+   **Kimi Code** — `engine: "kimi"`
+   - Install: `npm install -g @moonshot-ai/kimi-code`
+   - Authenticate: `kimi login` (OAuth, uses your Moonshot subscription) or set `KIMI_API_KEY` in `.env`.
+   - Verify: `kimi --version`.
+
+   **Codex CLI** — `engine: "codex"`
+   - Install the Codex CLI (see the upstream project README for platform-specific binaries).
+   - Authenticate: `codex login` in a standalone terminal, or configure a profile / API key in `~/.codex/config.toml`.
+   - Verify: `codex exec --help`.
+   - Optional per-bot overrides: `codex.model`, `codex.profile`, `codex.approvalPolicy` (`untrusted` | `on-failure` | `on-request` | `never`), `codex.sandbox` (`read-only` | `workspace-write` | `danger-full-access`), `codex.extraArgs` (extra argv passed verbatim to `codex exec`), `codex.env` (extra env vars for the subprocess). `CODEX_EXECUTABLE_PATH` env var overrides auto-detection; `CODEX_APPROVAL_POLICY` / `CODEX_SANDBOX` provide global defaults.
+   - Session continuity uses `codex exec resume <thread_id>` — MetaBot stores the Codex thread id per `chatId` just like Claude sessions.
+   - Interactive tool approvals (`sendAnswer` / `resolveQuestion`) are **not** supported under Codex — use `approvalPolicy: "never"` and a sandbox level you trust, since the bridge cannot surface approval prompts back to Feishu.
+
 3. **Feishu app is configured** — See the setup guide below.
 
 ## HTTPS Setup (Required for Web Voice Mode)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetaBot
 
-**在飞书 / Telegram / 微信上用手机控制 Claude Code 或 Kimi Code — 写代码、管 Agent、自动化一切。**
+**在飞书 / Telegram / 微信上用手机控制 Claude Code、Kimi Code 或 Codex CLI — 写代码、管 Agent、自动化一切。**
 
 [![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
@@ -38,7 +38,10 @@ MetaBot 不是只绑定一家 — 两大顶级 AI 编码 Agent 都内置原生�
 ```json
 { "name": "bulma", "engine": "kimi",   "kimi": { "thinking": true } }
 { "name": "goku",  "engine": "claude" }
+{ "name": "vegeta", "engine": "codex", "codex": { "model": "gpt-5.4-codex" } }
 ```
+
+Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec resume` 续接聊天会话。启动 MetaBot 前，请先执行 `codex login` 或配置好 Codex API key/profile。
 
 前端 Bot 用 Claude、后端 Bot 用 Kimi？完全可以。Agent 总线让它们互相委派任务，对面跑什么引擎对调用方透明。
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
-# MetaBot
+<div align="center">
 
-**在飞书 / Telegram / 微信上用手机控制 Claude Code、Kimi Code 或 Codex CLI — 写代码、管 Agent、自动化一切。**
+# 🤖 MetaBot
 
-[![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
-[![GitHub stars](https://img.shields.io/github/stars/xvirobotics/metabot?style=flat-square)](https://github.com/xvirobotics/metabot)
+### 在飞书 / Telegram / 微信上用手机控制 Claude Code、Kimi Code 或 Codex CLI
 
-中文 | [English](README_EN.md) | [文档站](https://xvirobotics.com/metabot/zh/)
+*写代码 · 管 Agent · 自动化一切*
 
-> 支持 **Claude Code** 和 **Kimi Code** 双引擎 — 两家原生订阅都能直接用，无需 API Key。每个 Bot 可独立选引擎。
+<p>
+  <a href="https://github.com/xvirobotics/metabot/actions"><img src="https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=for-the-badge&label=CI&logo=github" alt="CI"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="License"></a>
+  <a href="https://github.com/xvirobotics/metabot"><img src="https://img.shields.io/github/stars/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Stars"></a>
+  <a href="https://github.com/xvirobotics/metabot/network/members"><img src="https://img.shields.io/github/forks/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Forks"></a>
+</p>
+
+<p>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
+  <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
+  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Engine-Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
+  <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
+  <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
+</p>
+
+<p>
+  <a href="https://feishu.cn"><img src="https://img.shields.io/badge/飞书_/_Lark-00D6B9?style=for-the-badge&logo=lark&logoColor=white" alt="Feishu/Lark"></a>
+  <a href="https://telegram.org"><img src="https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram"></a>
+  <a href="https://ilinkai.weixin.qq.com"><img src="https://img.shields.io/badge/微信_ClawBot-07C160?style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <img src="https://img.shields.io/badge/Web_UI-61DAFB?style=for-the-badge&logo=react&logoColor=white" alt="Web UI">
+</p>
+
+**中文** · [English](README_EN.md) · [📚 文档站](https://xvirobotics.com/metabot/zh/)
+
+</div>
+
+> 支持 **Claude Code**、**Kimi Code** 和 **Codex CLI** 三大引擎 — 订阅 / API Key 任你选，每个 Bot 可独立选引擎。
 
 ![MetaBot Demo](resources/metabot-demo.gif)
 
@@ -16,23 +40,23 @@
 curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash
 ```
 
-安装器引导一切：工作目录 → **引擎选择（Claude / Kimi）** → 订阅登录 → IM 平台 → PM2 自动启动。**5 分钟上手。**
+安装器引导一切：工作目录 → **引擎选择（Claude / Kimi / Codex）** → 订阅登录 → IM 平台 → PM2 自动启动。**5 分钟上手。**
 
 ---
 
-## 双引擎：Claude Code 与 Kimi Code 并列一等支持
+## 三引擎：Claude Code ✕ Kimi Code ✕ Codex CLI 并列一等支持
 
-MetaBot 不是只绑定一家 — 两大顶级 AI 编码 Agent 都内置原生支持，**你的订阅直接用**。
+MetaBot 不是只绑定一家 — 三大顶级 AI 编码 Agent 都内置原生支持，**你的订阅直接用**。
 
-| | **Claude Code**（Anthropic） | **Kimi Code**（Moonshot） |
-|---|---|---|
-| **订阅直连** | ✅ `claude login` OAuth，走 Claude Code 订阅 | ✅ `kimi login`，走 Kimi 订阅 |
-| **API Key 兜底** | ✅ `ANTHROPIC_API_KEY` / 第三方 Anthropic 兼容端 | ✅ Moonshot API Key |
-| **上下文窗口** | 200k（Opus/Sonnet 可选 1M） | 256k（kimi-for-coding） |
-| **工具能力** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | 同上（Kimi CLI 原生 + `.claude/skills/` 自动发现） |
-| **自主运行模式** | `bypassPermissions` | `yoloMode`（等价） |
-| **子 Agent** | `.claude/agents/*.md` 自动加载 | 仅内置 `default` / `okabe` |
-| **工作区说明** | `CLAUDE.md` | `AGENTS.md`（安装器自动建软链） |
+| | **Claude Code**（Anthropic） | **Kimi Code**（Moonshot） | **Codex CLI**（OpenAI） |
+|---|---|---|---|
+| **订阅直连** | ✅ `claude login` OAuth | ✅ `kimi login` | ✅ `codex login`，走 ChatGPT 订阅 |
+| **API Key 兜底** | ✅ `ANTHROPIC_API_KEY` / 第三方 Anthropic 兼容端 | ✅ Moonshot API Key | ✅ `OPENAI_API_KEY` / Codex profile |
+| **上下文窗口** | 200k（Opus/Sonnet 可选 1M） | 256k（kimi-for-coding） | 400k（gpt-5.x-codex） |
+| **工具能力** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | 同上（Kimi CLI 原生 + `.claude/skills/` 自动发现） | Codex CLI 原生 sandbox + shell 工具链 |
+| **自主运行模式** | `bypassPermissions` | `yoloMode`（等价） | `--dangerously-bypass-approvals-and-sandbox` |
+| **子 Agent** | `.claude/agents/*.md` 自动加载 | 仅内置 `default` / `okabe` | 暂不支持子 Agent |
+| **工作区说明** | `CLAUDE.md` | `AGENTS.md`（安装器自动建软链） | `AGENTS.md`（Codex 官方约定） |
 
 **配置只需一行** — 每个 Bot 独立选引擎：
 ```json
@@ -49,7 +73,7 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
 
 ## 你能用它做什么
 
-- **手机写代码** — 地铁上用飞书给 Claude Code / Kimi Code 发消息，它帮你改 bug、提 PR、跑测试
+- **手机写代码** — 地铁上用飞书给 Claude Code / Kimi Code / Codex CLI 发消息，它帮你改 bug、提 PR、跑测试
 - **多 Agent 协作** — 前端 Bot、后端 Bot、运维 Bot，各自独立工作空间（甚至独立引擎），通过 Agent 总线互相委派任务
 - **知识自生长** — Agent 把学到的东西存入 MetaMemory，组织每天都在变聪明，无需重新训练
 - **自动化流水线** — "每天早上9点搜 AI 新闻，总结 Top 5，存档" — 一句话搞定
@@ -58,11 +82,11 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
 
 ## 为什么选 MetaBot
 
-| | MetaBot | 直接用 Claude Code / Kimi Code | Dify / Coze |
+| | MetaBot | 直接用 Claude / Kimi / Codex CLI | Dify / Coze |
 |---|---|---|---|
 | **手机控制** | 飞书/TG/微信随时随地 | 只能在终端 | 有，但不能跑代码 |
-| **引擎选择** | Claude Code ✕ Kimi Code 双引擎 | 各自单一 | 无，只能调 API |
-| **订阅直连** | 两家原生订阅都直接用 | 一次只能登一个 | 不支持订阅 |
+| **引擎选择** | Claude ✕ Kimi ✕ Codex 三引擎 | 各自单一 | 无，只能调 API |
+| **订阅直连** | 三家原生订阅都直接用 | 一次只能登一个 | 不支持订阅 |
 | **代码能力** | 完整 Agent SDK（Read/Write/Edit/Bash/MCP） | 完整 | 无 |
 | **多 Agent** | Agent 总线 + 任务委派 + 运行时创建 | 单会话 | 有，但封闭生态 |
 | **共享记忆** | MetaMemory 全文搜索 + 自动同步飞书知识库 | 无 | 无 |
@@ -76,7 +100,8 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
 
 ```
 飞书/TG/微信 → IM Bridge → Engine Router ──┬─→ Claude Code Agent SDK
-                                            └─→ Kimi Agent SDK（@moonshot-ai/kimi-agent-sdk）
+                                            ├─→ Kimi Agent SDK（@moonshot-ai/kimi-agent-sdk）
+                                            └─→ Codex CLI（codex exec --json 子进程）
                               ↕
                     MetaMemory（共享知识库）
                     MetaSkill（Agent 工厂，产出 CLAUDE.md + AGENTS.md）
@@ -84,7 +109,7 @@ Codex 支持通过本机 `codex exec --json` CLI 接入，并使用 `codex exec 
                     Agent 总线（跨 Bot 通信，引擎无关）
 ```
 
-引擎层已抽象 —— Kimi 事件流被翻译成 Claude 形状的 `SDKMessage`，流式卡片、工具调用追踪、MetaMemory/调度/Agent 总线在两种引擎下表现一致。
+引擎层已抽象 —— Kimi 事件流和 Codex JSONL 都被翻译成 Claude 形状的 `SDKMessage`，流式卡片、工具调用追踪、MetaMemory/调度/Agent 总线在三种引擎下表现一致。
 
 ## 多端接入
 
@@ -125,7 +150,7 @@ MetaBot 支持 4 种方式与你的 Agent 团队交互：
 
 | 组件 | 一句话说明 |
 |------|-----------|
-| **双引擎内核** | 每个 Bot 独立选 Claude Code 或 Kimi Code — 完整工具链（Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP），自主模式运行 |
+| **三引擎内核** | 每个 Bot 独立选 Claude Code / Kimi Code / Codex CLI — 完整工具链（Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP），自主模式运行 |
 | **MetaSkill** | Agent 工厂。`/metaskill` 一键生成 `.claude/` Agent 团队（orchestrator + 专家 + reviewer） |
 | **MetaMemory** | 内嵌 SQLite 知识库，全文搜索，Web UI，变更自动同步到飞书知识库 |
 | **IM Bridge** | 飞书、Telegram、微信（含手机端）对话任意 Agent，流式卡片 + 工具调用追踪 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,14 +1,38 @@
-# MetaBot
+<div align="center">
 
-**Control Claude Code, Kimi Code, or Codex CLI from your phone via Feishu / Telegram / WeChat — write code, manage agents, automate everything.**
+# 🤖 MetaBot
 
-[![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
-[![GitHub stars](https://img.shields.io/github/stars/xvirobotics/metabot?style=flat-square)](https://github.com/xvirobotics/metabot)
+### Control Claude Code, Kimi Code, or Codex CLI from your phone via Feishu / Telegram / WeChat
 
-[中文](README.md) | English | [Docs](https://xvirobotics.com/metabot/)
+*Write code · Manage agents · Automate everything*
 
-> **Claude Code** and **Kimi Code** — both first-class engines. Use either subscription natively, no API key required. Each bot picks its own engine.
+<p>
+  <a href="https://github.com/xvirobotics/metabot/actions"><img src="https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=for-the-badge&label=CI&logo=github" alt="CI"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="License"></a>
+  <a href="https://github.com/xvirobotics/metabot"><img src="https://img.shields.io/github/stars/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Stars"></a>
+  <a href="https://github.com/xvirobotics/metabot/network/members"><img src="https://img.shields.io/github/forks/xvirobotics/metabot?style=for-the-badge&logo=github" alt="Forks"></a>
+</p>
+
+<p>
+  <a href="https://github.com/anthropics/claude-code"><img src="https://img.shields.io/badge/Engine-Claude_Code-D97757?style=for-the-badge&logo=anthropic&logoColor=white" alt="Claude Code"></a>
+  <a href="https://platform.moonshot.ai"><img src="https://img.shields.io/badge/Engine-Kimi_Code-1A73E8?style=for-the-badge&logoColor=white" alt="Kimi Code"></a>
+  <a href="https://github.com/openai/codex"><img src="https://img.shields.io/badge/Engine-Codex_CLI-412991?style=for-the-badge&logo=openai&logoColor=white" alt="Codex CLI"></a>
+  <img src="https://img.shields.io/badge/Subscription-Native-22C55E?style=for-the-badge&logo=key&logoColor=white" alt="Native Subscription">
+  <img src="https://img.shields.io/badge/Node.js-20+-339933?style=for-the-badge&logo=node.js&logoColor=white" alt="Node.js">
+</p>
+
+<p>
+  <a href="https://feishu.cn"><img src="https://img.shields.io/badge/Feishu_/_Lark-00D6B9?style=for-the-badge&logo=lark&logoColor=white" alt="Feishu/Lark"></a>
+  <a href="https://telegram.org"><img src="https://img.shields.io/badge/Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram"></a>
+  <a href="https://ilinkai.weixin.qq.com"><img src="https://img.shields.io/badge/WeChat_ClawBot-07C160?style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <img src="https://img.shields.io/badge/Web_UI-61DAFB?style=for-the-badge&logo=react&logoColor=white" alt="Web UI">
+</p>
+
+[中文](README.md) · **English** · [📚 Docs](https://xvirobotics.com/metabot/)
+
+</div>
+
+> **Claude Code**, **Kimi Code**, and **Codex CLI** — three first-class engines. Subscription or API key, your choice. Each bot picks its own engine.
 
 ![MetaBot Demo](resources/metabot-demo.gif)
 
@@ -16,23 +40,23 @@
 curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh | bash
 ```
 
-The installer walks you through everything: working directory → **engine choice (Claude / Kimi)** → subscription login → IM platform → auto-start with PM2. **5 minutes to get started.**
+The installer walks you through everything: working directory → **engine choice (Claude / Kimi / Codex)** → subscription login → IM platform → auto-start with PM2. **5 minutes to get started.**
 
 ---
 
 ## Multi-Engine: Claude Code, Kimi Code, and Codex CLI
 
-MetaBot isn't locked to one vendor — both top AI coding agents ship with native support, and **your subscription works directly**.
+MetaBot isn't locked to one vendor — all three top AI coding agents ship with native support, and **your subscription works directly**.
 
-| | **Claude Code** (Anthropic) | **Kimi Code** (Moonshot) |
-|---|---|---|
-| **Subscription login** | ✅ `claude login` OAuth — uses your Claude Code subscription | ✅ `kimi login` — uses your Kimi subscription |
-| **API key fallback** | ✅ `ANTHROPIC_API_KEY` or third-party Anthropic-compat endpoints | ✅ Moonshot API key |
-| **Context window** | 200k (1M optional on Opus/Sonnet) | 256k (kimi-for-coding) |
-| **Tools** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | Same (Kimi CLI builtin + `.claude/skills/` auto-discovery) |
-| **Autonomous mode** | `bypassPermissions` | `yoloMode` (equivalent) |
-| **Subagents** | `.claude/agents/*.md` auto-loaded | Builtin `default` / `okabe` only |
-| **Workspace doc** | `CLAUDE.md` | `AGENTS.md` (installer creates the symlink) |
+| | **Claude Code** (Anthropic) | **Kimi Code** (Moonshot) | **Codex CLI** (OpenAI) |
+|---|---|---|---|
+| **Subscription login** | ✅ `claude login` OAuth | ✅ `kimi login` | ✅ `codex login` — uses your ChatGPT subscription |
+| **API key fallback** | ✅ `ANTHROPIC_API_KEY` or third-party Anthropic-compat endpoints | ✅ Moonshot API key | ✅ `OPENAI_API_KEY` / Codex profile |
+| **Context window** | 200k (1M optional on Opus/Sonnet) | 256k (kimi-for-coding) | 400k (gpt-5.x-codex) |
+| **Tools** | Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP | Same (Kimi CLI builtin + `.claude/skills/` auto-discovery) | Codex CLI native sandbox + shell toolchain |
+| **Autonomous mode** | `bypassPermissions` | `yoloMode` (equivalent) | `--dangerously-bypass-approvals-and-sandbox` |
+| **Subagents** | `.claude/agents/*.md` auto-loaded | Builtin `default` / `okabe` only | Subagents not supported yet |
+| **Workspace doc** | `CLAUDE.md` | `AGENTS.md` (installer creates the symlink) | `AGENTS.md` (Codex convention) |
 
 **One line of config** — each bot picks its engine:
 ```json
@@ -49,7 +73,7 @@ Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The 
 
 ## What You Can Build
 
-- **Code from your phone** — message Claude Code / Kimi Code from Feishu on the subway, it fixes bugs, opens PRs, runs tests
+- **Code from your phone** — message Claude Code / Kimi Code / Codex CLI from Feishu on the subway, it fixes bugs, opens PRs, runs tests
 - **Multi-agent teams** — frontend bot, backend bot, infra bot, each in their own workspace (even their own engine), delegating via Agent Bus
 - **Self-growing knowledge** — agents save what they learn to MetaMemory, the organization gets smarter daily
 - **Automated pipelines** — "Search AI news every morning at 9am, summarize top 5, save to archive" — one sentence
@@ -58,11 +82,11 @@ Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The 
 
 ## Why MetaBot
 
-| | MetaBot | Claude Code / Kimi Code (terminal) | Dify / Coze |
+| | MetaBot | Claude / Kimi / Codex CLI (terminal) | Dify / Coze |
 |---|---|---|---|
 | **Mobile access** | Feishu/TG/WeChat anywhere | Terminal only | Yes, but can't run code |
-| **Engine choice** | Claude Code ✕ Kimi Code dual-engine | One at a time | None, API calls only |
-| **Subscription login** | Both native subscriptions work directly | One at a time | Subscriptions not supported |
+| **Engine choice** | Claude ✕ Kimi ✕ Codex, three engines | One at a time | None, API calls only |
+| **Subscription login** | All three native subscriptions work directly | One at a time | Subscriptions not supported |
 | **Code capabilities** | Full Agent SDK (Read/Write/Edit/Bash/MCP) | Full | None |
 | **Multi-agent** | Agent Bus + task delegation + runtime creation | Single session | Yes, but closed ecosystem |
 | **Shared memory** | MetaMemory with FTS + auto-sync to Wiki | None | None |
@@ -76,7 +100,8 @@ Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The 
 
 ```
 Feishu/TG/WeChat → IM Bridge → Engine Router ──┬─→ Claude Code Agent SDK
-                                                └─→ Kimi Agent SDK (@moonshot-ai/kimi-agent-sdk)
+                                                ├─→ Kimi Agent SDK (@moonshot-ai/kimi-agent-sdk)
+                                                └─→ Codex CLI (codex exec --json subprocess)
                                     ↕
                          MetaMemory (shared knowledge)
                          MetaSkill (agent factory, emits CLAUDE.md + AGENTS.md)
@@ -84,7 +109,7 @@ Feishu/TG/WeChat → IM Bridge → Engine Router ──┬─→ Claude Code Age
                          Agent Bus (cross-bot comms, engine-agnostic)
 ```
 
-The engine layer is abstracted — Kimi's event stream is translated into Claude-shaped `SDKMessage` objects, so streaming cards, tool-call tracking, MetaMemory/Scheduler/Agent Bus behave identically regardless of engine.
+The engine layer is abstracted — Kimi's event stream and Codex's JSONL stream are both translated into Claude-shaped `SDKMessage` objects, so streaming cards, tool-call tracking, MetaMemory/Scheduler/Agent Bus behave identically across all three engines.
 
 | Client | Use Case | Key Features |
 |--------|----------|-------------|
@@ -121,7 +146,7 @@ Full-featured browser-based chat interface. Access at `https://your-server/web/`
 
 | Component | Description |
 |-----------|-------------|
-| **Dual Engine Kernel** | Each bot independently chooses Claude Code or Kimi Code — full tool stack (Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP) in autonomous mode |
+| **Triple Engine Kernel** | Each bot independently chooses Claude Code / Kimi Code / Codex CLI — full tool stack (Read/Write/Edit/Bash/Glob/Grep/WebSearch/MCP) in autonomous mode |
 | **MetaSkill** | Agent factory. `/metaskill` generates a complete `.claude/` agent team (orchestrator + specialists + reviewer) |
 | **MetaMemory** | Embedded SQLite knowledge store with full-text search, Web UI, auto-syncs to Feishu Wiki |
 | **IM Bridge** | Chat with any agent from Feishu, Telegram, or WeChat (including mobile). Streaming cards + tool call tracking |

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,6 +1,6 @@
 # MetaBot
 
-**Control Claude Code or Kimi Code from your phone via Feishu / Telegram / WeChat — write code, manage agents, automate everything.**
+**Control Claude Code, Kimi Code, or Codex CLI from your phone via Feishu / Telegram / WeChat — write code, manage agents, automate everything.**
 
 [![CI](https://img.shields.io/github/actions/workflow/status/xvirobotics/metabot/ci.yml?branch=main&style=flat-square)](https://github.com/xvirobotics/metabot/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
@@ -20,7 +20,7 @@ The installer walks you through everything: working directory → **engine choic
 
 ---
 
-## Dual Engine: Claude Code and Kimi Code, First-Class
+## Multi-Engine: Claude Code, Kimi Code, and Codex CLI
 
 MetaBot isn't locked to one vendor — both top AI coding agents ship with native support, and **your subscription works directly**.
 
@@ -38,7 +38,10 @@ MetaBot isn't locked to one vendor — both top AI coding agents ship with nativ
 ```json
 { "name": "bulma", "engine": "kimi",   "kimi": { "thinking": true } }
 { "name": "goku",  "engine": "claude" }
+{ "name": "vegeta", "engine": "codex", "codex": { "model": "gpt-5.4-codex" } }
 ```
+
+Codex support uses the local `codex exec --json` CLI and resumes chat sessions with `codex exec resume`. Authenticate once with `codex login` (or configure your Codex API key/profile) before starting MetaBot.
 
 Run your frontend bot on Claude and your backend bot on Kimi? Totally fine. The Agent Bus lets them delegate to each other — the calling bot doesn't need to know which engine is on the other side.
 
@@ -345,7 +348,7 @@ MetaBot runs Claude Code in `bypassPermissions` mode — no interactive approval
 | `/reset` | Clear session |
 | `/stop` | Abort current task |
 | `/status` | Session info (includes current model) |
-| `/model` | Show current model; `/model list` — available models; `/model <name>` — switch; `/model reset` — restore default |
+| `/model` | Show current engine/model; `/model list` — available engines/models; `/model claude`, `/model kimi`, or `/model codex` — switch engine; `/model <name>` — set model; `/model reset` — restore default |
 | `/memory list` | Browse knowledge tree |
 | `/memory search <query>` | Search knowledge base |
 | `/sync` | Sync MetaMemory to Feishu Wiki |

--- a/bots.example.json
+++ b/bots.example.json
@@ -36,6 +36,19 @@
         "model": "kimi-latest",
         "thinking": true
       }
+    },
+    {
+      "name": "project-delta",
+      "description": "Codex-powered agent (uses Codex CLI)",
+      "engine": "codex",
+      "feishuAppId": "cli_codex",
+      "feishuAppSecret": "secret4",
+      "defaultWorkingDirectory": "/home/user/project-delta",
+      "codex": {
+        "model": "gpt-5.4-codex",
+        "approvalPolicy": "never",
+        "sandbox": "workspace-write"
+      }
     }
   ],
   "telegramBots": [

--- a/install.sh
+++ b/install.sh
@@ -350,6 +350,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
   echo -e "${BOLD}Agent Engine:${NC}"
   echo "  1) Claude Code (Anthropic)"
   echo "  2) Kimi (Moonshot AI — requires kimi-cli login, uses your subscription)"
+  echo "  3) Codex CLI (OpenAI — requires codex login, uses your ChatGPT subscription)"
   prompt_choice ENGINE_CHOICE "1"
 
   BOT_ENGINE="claude"
@@ -365,6 +366,26 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     info "After install, run 'kimi login' in a separate terminal to authenticate."
     # Skip the Claude provider prompt entirely for Kimi — it has its own auth.
     AUTH_CHOICE="kimi"
+  elif [[ "$ENGINE_CHOICE" == "3" ]]; then
+    BOT_ENGINE="codex"
+    CLAUDE_AUTH_METHOD="codex"
+    echo ""
+    if command -v codex &>/dev/null; then
+      success "Codex CLI found: $(command -v codex)"
+    else
+      info "Installing Codex CLI..."
+      npm_install_global @openai/codex
+      if command -v codex &>/dev/null; then
+        success "Codex CLI installed: $(command -v codex)"
+      else
+        warn "Codex CLI install failed. Install manually: sudo npm install -g @openai/codex"
+        warn "MetaBot will still be configured — install Codex + run 'codex login' before starting."
+      fi
+    fi
+    info "After install, run 'codex login' in a separate terminal to authenticate (or set OPENAI_API_KEY / configure a profile in ~/.codex/config.toml)."
+    info "Note: Codex runs with approvalPolicy='never' and sandbox='workspace-write' by default — interactive tool approvals are not surfaced to IM."
+    # Skip the Claude provider prompt entirely for Codex — it has its own auth.
+    AUTH_CHOICE="codex"
   else
     # ------ 4b-claude: Claude AI authentication ------
     echo ""
@@ -376,7 +397,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
   fi
 
   case "$AUTH_CHOICE" in
-    kimi)
+    kimi|codex)
       : # handled above
       ;;
     1)
@@ -525,9 +546,16 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
     echo "API_PORT=${API_PORT}"
     echo "API_SECRET=${API_SECRET}"
     echo ""
-    echo "# Claude AI Authentication"
+    echo "# Agent Engine Authentication"
     if [[ "$CLAUDE_AUTH_METHOD" == "subscription" ]]; then
       echo "# Using Claude Code Subscription (OAuth). Run 'claude login' to authenticate."
+    elif [[ "$CLAUDE_AUTH_METHOD" == "kimi" ]]; then
+      echo "# Using Kimi CLI. Run 'kimi login' to authenticate."
+    elif [[ "$CLAUDE_AUTH_METHOD" == "codex" ]]; then
+      echo "# Using Codex CLI. Run 'codex login' to authenticate (or set OPENAI_API_KEY / configure ~/.codex/config.toml)."
+      echo "# CODEX_EXECUTABLE_PATH="
+      echo "# CODEX_APPROVAL_POLICY=never"
+      echo "# CODEX_SANDBOX=workspace-write"
     elif [[ -n "${CLAUDE_AUTH_ENV_LINES:-}" ]]; then
       echo "$CLAUDE_AUTH_ENV_LINES"
     fi
@@ -563,6 +591,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         defaultWorkingDirectory: process.argv[4],
       };
       if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$BOT_NAME" "$FEISHU_APP_ID" "$FEISHU_APP_SECRET" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -578,6 +607,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         defaultWorkingDirectory: process.argv[3],
       };
       if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$TG_NAME" "$TELEGRAM_BOT_TOKEN" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -593,6 +623,7 @@ if [[ "$SKIP_CONFIG" == "false" ]]; then
         defaultWorkingDirectory: process.argv[2],
       };
       if (engine === 'kimi') { bot.engine = 'kimi'; bot.kimi = { thinking: true }; }
+      if (engine === 'codex') { bot.engine = 'codex'; bot.codex = { approvalPolicy: 'never', sandbox: 'workspace-write' }; }
       console.log(JSON.stringify([bot], null, 2))
     " "$WX_NAME" "$WORK_DIR" "${BOT_ENGINE:-claude}")
   fi
@@ -1107,6 +1138,14 @@ if [[ "${SKIP_CONFIG}" == "false" ]]; then
   fi
   if [[ "${CLAUDE_AUTH_METHOD}" == "kimi" ]]; then
     echo "    ${STEP_NUM}. Run 'kimi login' in a separate terminal (https://kimi.com to sign up)"
+    STEP_NUM=$((STEP_NUM + 1))
+  fi
+  if [[ "${CLAUDE_AUTH_METHOD}" == "codex" ]]; then
+    if ! command -v codex &>/dev/null; then
+      echo "    ${STEP_NUM}. Install Codex CLI: sudo npm install -g @openai/codex"
+      STEP_NUM=$((STEP_NUM + 1))
+    fi
+    echo "    ${STEP_NUM}. Run 'codex login' in a separate terminal (or set OPENAI_API_KEY / configure ~/.codex/config.toml)"
     STEP_NUM=$((STEP_NUM + 1))
   fi
   if [[ "$SETUP_FEISHU" == "true" ]]; then

--- a/src/api/bot-registry.ts
+++ b/src/api/bot-registry.ts
@@ -1,5 +1,6 @@
 import type * as lark from '@larksuiteoapi/node-sdk';
 import type { BotConfigBase } from '../config.js';
+import { resolveEngineName, type EngineName } from '../engines/index.js';
 import type { MessageBridge } from '../bridge/message-bridge.js';
 import type { IMessageSender } from '../bridge/message-sender.interface.js';
 
@@ -20,6 +21,8 @@ export interface BotInfo {
   specialties?: string[];
   icon?: string;
   platform: string;
+  engine: EngineName;
+  model?: string;
   workingDirectory: string;
   ttsVoice?: string;
   /** Set when the bot comes from a peer instance. */
@@ -87,8 +90,21 @@ export class BotRegistry {
       ...(b.config.specialties?.length ? { specialties: b.config.specialties } : {}),
       ...(b.config.icon ? { icon: b.config.icon } : {}),
       platform: b.platform,
+      engine: resolveEngineName(b.config),
+      ...(defaultModelForEngine(b.config) ? { model: defaultModelForEngine(b.config) } : {}),
       workingDirectory: b.config.claude.defaultWorkingDirectory,
       ...(b.config.ttsVoice ? { ttsVoice: b.config.ttsVoice } : {}),
     }));
+  }
+}
+
+function defaultModelForEngine(config: BotConfigBase): string | undefined {
+  switch (resolveEngineName(config)) {
+    case 'claude':
+      return config.claude.model;
+    case 'kimi':
+      return config.kimi?.model;
+    case 'codex':
+      return config.codex?.model || config.codex?.displayModel;
   }
 }

--- a/src/api/peer-manager.ts
+++ b/src/api/peer-manager.ts
@@ -114,6 +114,8 @@ export class PeerManager {
           name: string;
           description?: string;
           platform: string;
+          engine?: BotInfo['engine'];
+          model?: string;
           workingDirectory: string;
           peerUrl?: string;
         }>;
@@ -126,6 +128,8 @@ export class PeerManager {
           name: b.name,
           ...(b.description ? { description: b.description } : {}),
           platform: b.platform,
+          engine: b.engine ?? 'claude',
+          ...(b.model ? { model: b.model } : {}),
           workingDirectory: b.workingDirectory,
           peerUrl: config.url,
           peerName: config.name,

--- a/src/api/routes/bot-routes.ts
+++ b/src/api/routes/bot-routes.ts
@@ -3,6 +3,7 @@ import type * as http from 'node:http';
 import { addBot, removeBot, updateBot, getBotEntry } from '../bots-config-writer.js';
 import { installSkillsToWorkDir } from '../skills-installer.js';
 import { webBotFromJson } from '../../config.js';
+import { resolveEngineName } from '../../engines/index.js';
 import { NullSender } from '../../web/null-sender.js';
 import { MessageBridge } from '../../bridge/message-bridge.js';
 import { jsonResponse, parseJsonBody } from './helpers.js';
@@ -30,6 +31,8 @@ export async function handleBotRoutes(
     jsonResponse(res, 200, {
       name: bot.name, description: bot.config.description, specialties: bot.config.specialties,
       icon: bot.config.icon, platform: bot.platform,
+      engine: resolveEngineName(bot.config),
+      model: defaultModelForConfig(bot.config),
       workingDirectory: bot.config.claude.defaultWorkingDirectory,
       maxConcurrentTasks: bot.config.maxConcurrentTasks, budgetLimitDaily: bot.config.budgetLimitDaily,
       stats: botStats || { totalTasks: 0, completedTasks: 0, failedTasks: 0, totalCostUsd: 0 },
@@ -81,6 +84,9 @@ export async function handleBotRoutes(
       }
       entry = {
         name, ...(body.description ? { description: body.description } : {}),
+        ...(body.engine ? { engine: body.engine } : {}),
+        ...(body.codex ? { codex: body.codex } : {}),
+        ...(body.kimi ? { kimi: body.kimi } : {}),
         feishuAppId: appId, feishuAppSecret: appSecret, defaultWorkingDirectory: workDir,
         ...(body.maxTurns ? { maxTurns: body.maxTurns } : {}),
         ...(body.maxBudgetUsd ? { maxBudgetUsd: body.maxBudgetUsd } : {}),
@@ -95,6 +101,9 @@ export async function handleBotRoutes(
       }
       entry = {
         name, ...(body.description ? { description: body.description } : {}),
+        ...(body.engine ? { engine: body.engine } : {}),
+        ...(body.codex ? { codex: body.codex } : {}),
+        ...(body.kimi ? { kimi: body.kimi } : {}),
         telegramBotToken: token, defaultWorkingDirectory: workDir,
         ...(body.maxTurns ? { maxTurns: body.maxTurns } : {}),
         ...(body.maxBudgetUsd ? { maxBudgetUsd: body.maxBudgetUsd } : {}),
@@ -108,6 +117,9 @@ export async function handleBotRoutes(
       }
       entry = {
         name, ...(body.description ? { description: body.description } : {}),
+        ...(body.engine ? { engine: body.engine } : {}),
+        ...(body.codex ? { codex: body.codex } : {}),
+        ...(body.kimi ? { kimi: body.kimi } : {}),
         defaultWorkingDirectory: workDir,
         ...(body.maxTurns ? { maxTurns: body.maxTurns } : {}),
         ...(body.maxBudgetUsd ? { maxBudgetUsd: body.maxBudgetUsd } : {}),
@@ -238,4 +250,15 @@ export async function handleBotRoutes(
   }
 
   return false;
+}
+
+function defaultModelForConfig(config: import('../../config.js').BotConfigBase): string | undefined {
+  switch (resolveEngineName(config)) {
+    case 'claude':
+      return config.claude.model;
+    case 'kimi':
+      return config.kimi?.model;
+    case 'codex':
+      return config.codex?.model || config.codex?.displayModel;
+  }
 }

--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -2,7 +2,8 @@ import type { BotConfigBase } from '../config.js';
 import type { Logger } from '../utils/logger.js';
 import type { IncomingMessage } from '../types.js';
 import type { IMessageSender } from './message-sender.interface.js';
-import { SessionManager } from '../engines/index.js';
+import { resolveEngineName, SessionManager } from '../engines/index.js';
+import type { EngineName } from '../engines/index.js';
 import { MemoryClient } from '../memory/memory-client.js';
 import { AuditLogger } from '../utils/audit-logger.js';
 import type { DocSync } from '../sync/doc-sync.js';
@@ -59,7 +60,7 @@ export class CommandHandler {
           '`/stop` - Abort current running task',
           '`/status` - Show current session info',
           '`/model` - Show current engine/model; `/model list` - Available options',
-          '`/model claude` or `/model kimi` - Switch engine (resets session)',
+          '`/model claude`, `/model kimi`, or `/model codex` - Switch engine (resets session)',
           '`/model <name>` - Set model for current engine',
           '`/memory` - Memory document commands',
           '`/model [opus|sonnet|haiku]` - View or switch Claude model',
@@ -72,7 +73,7 @@ export class CommandHandler {
           '`/help` - Show this help message',
           '',
           '**Usage:**',
-          'Send any text message to start a conversation with Claude Code.',
+          'Send any text message to start a conversation with the configured agent engine.',
           'Each chat has an independent session with a fixed working directory.',
           '',
           '**Memory Commands:**',
@@ -115,11 +116,9 @@ export class CommandHandler {
       case '/status': {
         const session = this.sessionManager.getSession(chatId);
         const isRunning = !!this.getRunningTask(chatId);
-        const botEngine = this.config.engine ?? 'claude';
+        const botEngine = resolveEngineName(this.config);
         const activeEngine = session.engine ?? botEngine;
-        const defaultModel = activeEngine === 'kimi'
-          ? (this.config.kimi?.model || '_default_')
-          : (this.config.claude.model || '_default_');
+        const defaultModel = this.defaultModelForEngine(activeEngine) || '_default_';
         const activeModel = session.model || defaultModel;
         await this.sender.sendTextNotice(chatId, '📊 Status', [
           `**User:** \`${userId}\``,
@@ -429,18 +428,14 @@ export class CommandHandler {
 
   private async handleModelCommand(chatId: string, args: string): Promise<void> {
     const session = this.sessionManager.getSession(chatId);
-    const botEngine = this.config.engine ?? 'claude';
+    const botEngine = resolveEngineName(this.config);
     const activeEngine = session.engine ?? botEngine;
-    const botDefault =
-      activeEngine === 'kimi' ? this.config.kimi?.model : this.config.claude.model;
+    const botDefault = this.defaultModelForEngine(activeEngine);
 
     // No args — show current model
     if (!args) {
       const active = session.model || botDefault || '_default_';
-      const exampleModels =
-        activeEngine === 'kimi'
-          ? '`kimi-for-coding`, `kimi-k2`'
-          : '`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`';
+      const exampleModels = this.exampleModelsForEngine(activeEngine);
       const lines = [
         `**Engine:** \`${activeEngine}\`${session.engine ? ' (session override)' : ''}`,
         `**Active:** \`${active}\`${session.model ? ' (session override)' : ''}`,
@@ -448,7 +443,7 @@ export class CommandHandler {
         '',
         'Usage:',
         '- `/model list` — Show available engines + models',
-        '- `/model claude` or `/model kimi` — Switch engine (resets session)',
+        '- `/model claude`, `/model kimi`, or `/model codex` — Switch engine (resets session)',
         `- \`/model <name>\` — Set session model (e.g. ${exampleModels})`,
         '- `/model reset` — Clear overrides, use bot defaults',
       ];
@@ -458,8 +453,8 @@ export class CommandHandler {
 
     const normalized = args.toLowerCase();
 
-    // Engine switch — /model claude or /model kimi
-    if (normalized === 'claude' || normalized === 'kimi') {
+    // Engine switch — /model claude, /model kimi, or /model codex
+    if (isEngineName(normalized)) {
       if (activeEngine === normalized) {
         await this.sender.sendTextNotice(
           chatId,
@@ -477,9 +472,7 @@ export class CommandHandler {
           `Next message will run on the **${normalized}** engine.`,
           '',
           '_Session ID and model override cleared — a fresh conversation starts on the next turn._',
-          normalized === 'kimi'
-            ? '_Make sure `kimi login` has been completed on this host._'
-            : '_Make sure Claude Code is authenticated (`claude login`)._',
+          this.authTipForEngine(normalized),
         ].join('\n'),
         'green',
       );
@@ -502,12 +495,21 @@ export class CommandHandler {
         { id: 'kimi-for-coding', label: 'Kimi for Coding', note: 'Subscription default · 256k context · thinking' },
         { id: 'kimi-k2', label: 'Kimi K2', note: 'Legacy coding model' },
       ];
-      const models = activeEngine === 'kimi' ? kimiModels : claudeModels;
-      const header = activeEngine === 'kimi' ? '**Available Kimi models:**' : '**Available Claude models:**';
+      const codexModels = [
+        { id: 'gpt-5.4-codex', label: 'GPT-5.4 Codex', note: 'Recommended Codex coding model' },
+        { id: 'gpt-5.4', label: 'GPT-5.4', note: 'General flagship model' },
+        { id: 'gpt-5.2-codex', label: 'GPT-5.2 Codex', note: 'Legacy Codex coding model' },
+      ];
+      const models = activeEngine === 'kimi' ? kimiModels : activeEngine === 'codex' ? codexModels : claudeModels;
+      const header = activeEngine === 'kimi'
+        ? '**Available Kimi models:**'
+        : activeEngine === 'codex'
+          ? '**Common Codex models:**'
+          : '**Available Claude models:**';
       const lines = [
         `**Current engine:** \`${activeEngine}\`${session.engine ? ' (session override)' : ''}`,
         '',
-        '**Engines:** `/model claude` or `/model kimi` to switch.',
+        '**Engines:** `/model claude`, `/model kimi`, or `/model codex` to switch.',
         '',
         header,
         '',
@@ -519,6 +521,8 @@ export class CommandHandler {
       lines.push('');
       if (activeEngine === 'claude') {
         lines.push('_Tip: append `[1m]` to a model name to enable the 1M context window. Only Opus 4.7/4.6 and Sonnet 4.6 support it._');
+      } else if (activeEngine === 'codex') {
+        lines.push('_Tip: leave unset to use the Codex CLI default from `~/.codex/config.toml`._');
       } else {
         lines.push('_Tip: leave unset to use the kimi-cli default (recommended for subscription users — the server picks the best available)._');
       }
@@ -551,4 +555,41 @@ export class CommandHandler {
       'green',
     );
   }
+
+  private defaultModelForEngine(engine: EngineName): string | undefined {
+    switch (engine) {
+      case 'claude':
+        return this.config.claude.model;
+      case 'kimi':
+        return this.config.kimi?.model;
+      case 'codex':
+        return this.config.codex?.model || this.config.codex?.displayModel;
+    }
+  }
+
+  private exampleModelsForEngine(engine: EngineName): string {
+    switch (engine) {
+      case 'claude':
+        return '`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`';
+      case 'kimi':
+        return '`kimi-for-coding`, `kimi-k2`';
+      case 'codex':
+        return '`gpt-5.4-codex`, `gpt-5.4`, `gpt-5.2-codex`';
+    }
+  }
+
+  private authTipForEngine(engine: EngineName): string {
+    switch (engine) {
+      case 'claude':
+        return '_Make sure Claude Code is authenticated (`claude login`)._';
+      case 'kimi':
+        return '_Make sure `kimi login` has been completed on this host._';
+      case 'codex':
+        return '_Make sure Codex CLI is authenticated (`codex login`) or configured with an API key._';
+    }
+  }
+}
+
+function isEngineName(value: string): value is EngineName {
+  return value === 'claude' || value === 'kimi' || value === 'codex';
 }

--- a/src/bridge/command-handler.ts
+++ b/src/bridge/command-handler.ts
@@ -547,7 +547,7 @@ export class CommandHandler {
 
     // Set the model (use only the first token, ignore trailing junk)
     const newModel = args.split(/\s+/)[0];
-    this.sessionManager.setSessionModel(chatId, newModel);
+    this.sessionManager.setSessionModel(chatId, newModel, activeEngine);
     await this.sender.sendTextNotice(
       chatId,
       '✅ Model Set',

--- a/src/bridge/message-bridge.ts
+++ b/src/bridge/message-bridge.ts
@@ -250,6 +250,37 @@ export class MessageBridge {
     return entry.executor;
   }
 
+  /**
+   * Session ids and model overrides are engine-specific. If a bot's default
+   * engine changes between restarts, discard the old per-chat state before the
+   * next execution so another engine does not try to resume it.
+   */
+  private prepareSessionForExecution(chatId: string): { session: ReturnType<SessionManager['getSession']>; engineName: EngineName } {
+    const session = this.sessionManager.getSession(chatId);
+    const engineName: EngineName = session.engine ?? resolveEngineName(this.config);
+
+    if (session.sessionId && session.sessionIdEngine && session.sessionIdEngine !== engineName) {
+      this.logger.info(
+        { chatId, sessionIdEngine: session.sessionIdEngine, engine: engineName },
+        'Clearing session id from a different engine',
+      );
+      this.sessionManager.resetSession(chatId);
+    }
+
+    if (session.model && session.modelEngine && session.modelEngine !== engineName) {
+      this.logger.info(
+        { chatId, modelEngine: session.modelEngine, engine: engineName },
+        'Clearing model override from a different engine',
+      );
+      this.sessionManager.setSessionModel(chatId, undefined);
+    }
+
+    return {
+      session: this.sessionManager.getSession(chatId),
+      engineName,
+    };
+  }
+
   /** Inject the doc sync service for /sync commands. */
   setDocSync(docSync: DocSync): void {
     this.commandHandler.setDocSync(docSync);
@@ -701,10 +732,10 @@ export class MessageBridge {
 
   private async executeQuery(msg: IncomingMessage): Promise<void> {
     const { userId, chatId, text, imageKey, fileKey, fileName, messageId: msgId } = msg;
-    const session = this.sessionManager.getSession(chatId);
+    const { session, engineName } = this.prepareSessionForExecution(chatId);
     const cwd = session.workingDirectory;
     const abortController = new AbortController();
-    const activeEngine = resolveEngineName(this.config);
+    const activeEngine = engineName;
     const enginePromptText = normalizePromptForEngine(text, activeEngine);
 
     // Prepare downloads directory (bot-isolated)
@@ -926,8 +957,8 @@ export class MessageBridge {
 
             // Update session ID if discovered
             const newSessionId = processor.getSessionId();
-            if (newSessionId && newSessionId !== session.sessionId) {
-              this.sessionManager.setSessionId(chatId, newSessionId);
+            if (newSessionId && (newSessionId !== session.sessionId || session.sessionIdEngine !== engineName)) {
+              this.sessionManager.setSessionId(chatId, newSessionId, engineName);
             }
 
             // Check if we hit a waiting_for_input state
@@ -1130,7 +1161,7 @@ export class MessageBridge {
           const state = processor.processMessage(message);
           lastState = state;
           const newSid = processor.getSessionId();
-          if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+          if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
           if (state.status === 'complete' || state.status === 'error') break;
           rateLimiter.schedule(() => { this.sender.updateCard(messageId, state); });
         }
@@ -1165,7 +1196,7 @@ export class MessageBridge {
             }
           }
           const newSid = processor.getSessionId();
-          if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+          if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
           if (state.status === 'complete' || state.status === 'error') break;
           if (needsRecreate && state.responseText) {
             await rateLimiter.flush();
@@ -1256,7 +1287,7 @@ export class MessageBridge {
               }
             }
             const newSid = processor.getSessionId();
-            if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+            if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
             if (state.status === 'complete' || state.status === 'error') break;
             if (needsRecreate && state.responseText) {
               await rateLimiter.flush();
@@ -1391,7 +1422,7 @@ export class MessageBridge {
       });
     }
 
-    const session = this.sessionManager.getSession(chatId);
+    const { session, engineName } = this.prepareSessionForExecution(chatId);
     const cwd = session.workingDirectory;
     const abortController = new AbortController();
 
@@ -1533,8 +1564,8 @@ export class MessageBridge {
             }
 
             const newSessionId = processor.getSessionId();
-            if (newSessionId && newSessionId !== session.sessionId) {
-              this.sessionManager.setSessionId(chatId, newSessionId);
+            if (newSessionId && (newSessionId !== session.sessionId || session.sessionIdEngine !== engineName)) {
+              this.sessionManager.setSessionId(chatId, newSessionId, engineName);
             }
 
             if (state.status === 'waiting_for_input' && state.pendingQuestion) {
@@ -1687,7 +1718,7 @@ export class MessageBridge {
             }
           }
           const newSid = processor.getSessionId();
-          if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+          if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
           if (state.status === 'complete' || state.status === 'error') break;
           if (sendCards && messageId) {
             if (needsRecreate && state.responseText) {
@@ -1789,7 +1820,7 @@ export class MessageBridge {
               }
             }
             const newSid = processor.getSessionId();
-            if (newSid) this.sessionManager.setSessionId(chatId, newSid);
+            if (newSid) this.sessionManager.setSessionId(chatId, newSid, engineName);
             if (state.status === 'complete' || state.status === 'error') break;
             if (sendCards && messageId) {
               if (needsRecreate && state.responseText) {
@@ -2207,7 +2238,7 @@ export class MessageBridge {
 
 export function isStaleSessionError(errorMessage?: string): boolean {
   if (!errorMessage) return false;
-  return /no conversation found|conversation not found|session id|invalid session|each tool_use must have a single result|multiple tool_result blocks/i.test(errorMessage);
+  return /no conversation found|conversation not found|session id|invalid session|thread\/resume.*failed|no rollout found|each tool_use must have a single result|multiple tool_result blocks/i.test(errorMessage);
 }
 
 export function normalizePromptForEngine(text: string, engine: EngineName): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,19 +56,22 @@ export interface BotConfigBase {
     contextWindow?: number;
   };
   /** Codex-specific overrides. Populated only when engine === 'codex'. */
-  codex?: {
-    executable?: string;
-    model?: string;
-    displayModel?: string;
-    profile?: string;
-    approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
-    sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
-    dangerouslyBypassApprovalsAndSandbox?: boolean;
-    /** Context window size in tokens for display only. */
-    contextWindow?: number;
-    extraArgs?: string[];
-    env?: Record<string, string>;
-  };
+  codex?: CodexBotConfig;
+}
+
+/** Codex-specific overrides. Populated only when engine === 'codex'. */
+export interface CodexBotConfig {
+  executable?: string;
+  model?: string;
+  displayModel?: string;
+  profile?: string;
+  approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+  dangerouslyBypassApprovalsAndSandbox?: boolean;
+  /** Context window size in tokens for display only. */
+  contextWindow?: number;
+  extraArgs?: string[];
+  env?: Record<string, string>;
 }
 
 export interface ApprovalConfigJsonEntry {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-/** Agent engine backing a bot. `claude` uses Claude Code; `kimi` uses Kimi Code (Phase 2). */
+/** Agent engine backing a bot. `claude` → Claude Code, `kimi` → Kimi Code, `codex` → Codex CLI. */
 export type EngineName = 'claude' | 'kimi' | 'codex';
 
 /** Shared config fields used by MessageBridge and Executors (platform-agnostic). */
@@ -54,6 +54,20 @@ export interface BotConfigBase {
     apiKey?: string;
     /** Context window size in tokens (defaults to 262144 — Kimi for Coding default). */
     contextWindow?: number;
+  };
+  /** Codex-specific overrides. Populated only when engine === 'codex'. */
+  codex?: {
+    executable?: string;
+    model?: string;
+    displayModel?: string;
+    profile?: string;
+    approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+    sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+    dangerouslyBypassApprovalsAndSandbox?: boolean;
+    /** Context window size in tokens for display only. */
+    contextWindow?: number;
+    extraArgs?: string[];
+    env?: Record<string, string>;
   };
 }
 
@@ -154,10 +168,26 @@ export interface KimiJsonConfig {
   contextWindow?: number;
 }
 
-/** Fields shared across all bot JSON entries (engine selection, Kimi overrides). */
+/** Codex-specific overrides in bots.json. */
+export interface CodexJsonConfig {
+  executable?: string;
+  model?: string;
+  displayModel?: string;
+  profile?: string;
+  approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+  dangerouslyBypassApprovalsAndSandbox?: boolean;
+  /** Context window size in tokens for display only. */
+  contextWindow?: number;
+  extraArgs?: string[];
+  env?: Record<string, string>;
+}
+
+/** Fields shared across all bot JSON entries (engine selection and engine overrides). */
 interface EngineJsonFields {
   engine?: EngineName;
   kimi?: KimiJsonConfig;
+  codex?: CodexJsonConfig;
 }
 
 export interface FeishuBotJsonEntry extends EngineJsonFields {
@@ -185,6 +215,7 @@ export interface FeishuBotJsonEntry extends EngineJsonFields {
 }
 
 function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
+  const codex = buildCodexConfig(entry.codex);
   return {
     name: entry.name,
     ...(entry.description ? { description: entry.description } : {}),
@@ -196,6 +227,7 @@ function feishuBotFromJson(entry: FeishuBotJsonEntry): BotConfig {
     ...(entry.groupNoMention ? { groupNoMention: true } : {}),
     ...(entry.engine ? { engine: entry.engine } : {}),
     ...(entry.kimi ? { kimi: entry.kimi } : {}),
+    ...(codex ? { codex } : {}),
     feishu: {
       appId: entry.feishuAppId,
       appSecret: entry.feishuAppSecret,
@@ -229,6 +261,7 @@ export interface TelegramBotJsonEntry extends EngineJsonFields {
 }
 
 function telegramBotFromJson(entry: TelegramBotJsonEntry): TelegramBotConfig {
+  const codex = buildCodexConfig(entry.codex);
   return {
     name: entry.name,
     ...(entry.description ? { description: entry.description } : {}),
@@ -239,6 +272,7 @@ function telegramBotFromJson(entry: TelegramBotJsonEntry): TelegramBotConfig {
     ...(entry.ttsVoice ? { ttsVoice: entry.ttsVoice } : {}),
     ...(entry.engine ? { engine: entry.engine } : {}),
     ...(entry.kimi ? { kimi: entry.kimi } : {}),
+    ...(codex ? { codex } : {}),
     telegram: {
       botToken: entry.telegramBotToken,
     },
@@ -267,6 +301,7 @@ export interface WebBotJsonEntry extends EngineJsonFields {
 }
 
 export function webBotFromJson(entry: WebBotJsonEntry): BotConfigBase {
+  const codex = buildCodexConfig(entry.codex);
   return {
     name: entry.name,
     ...(entry.description ? { description: entry.description } : {}),
@@ -277,6 +312,7 @@ export function webBotFromJson(entry: WebBotJsonEntry): BotConfigBase {
     ...(entry.ttsVoice ? { ttsVoice: entry.ttsVoice } : {}),
     ...(entry.engine ? { engine: entry.engine } : {}),
     ...(entry.kimi ? { kimi: entry.kimi } : {}),
+    ...(codex ? { codex } : {}),
     claude: buildClaudeConfig(entry),
     ...(entry.approval ? { approval: entry.approval } : {}),
   };
@@ -300,11 +336,13 @@ export interface WechatBotJsonEntry extends EngineJsonFields {
 }
 
 function wechatBotFromJson(entry: WechatBotJsonEntry): WechatBotConfig {
+  const codex = buildCodexConfig(entry.codex);
   return {
     name: entry.name,
     ...(entry.description ? { description: entry.description } : {}),
     ...(entry.engine ? { engine: entry.engine } : {}),
     ...(entry.kimi ? { kimi: entry.kimi } : {}),
+    ...(codex ? { codex } : {}),
     wechat: {
       ilinkBaseUrl: entry.ilinkBaseUrl,
       botToken: entry.wechatBotToken,
@@ -340,11 +378,29 @@ function buildClaudeConfig(entry: {
   };
 }
 
+function buildCodexConfig(entry?: CodexJsonConfig): BotConfigBase['codex'] | undefined {
+  const cfg: BotConfigBase['codex'] = {
+    ...(process.env.CODEX_EXECUTABLE_PATH ? { executable: process.env.CODEX_EXECUTABLE_PATH } : {}),
+    ...(process.env.CODEX_MODEL ? { model: process.env.CODEX_MODEL } : {}),
+    ...(process.env.CODEX_DISPLAY_MODEL ? { displayModel: process.env.CODEX_DISPLAY_MODEL } : {}),
+    ...(process.env.CODEX_PROFILE ? { profile: process.env.CODEX_PROFILE } : {}),
+    ...(process.env.CODEX_APPROVAL_POLICY ? { approvalPolicy: process.env.CODEX_APPROVAL_POLICY as CodexJsonConfig['approvalPolicy'] } : {}),
+    ...(process.env.CODEX_SANDBOX ? { sandbox: process.env.CODEX_SANDBOX as CodexJsonConfig['sandbox'] } : {}),
+    ...(process.env.CODEX_BYPASS_APPROVALS_AND_SANDBOX === 'true' ? { dangerouslyBypassApprovalsAndSandbox: true } : {}),
+    ...(process.env.CODEX_CONTEXT_WINDOW ? { contextWindow: parseInt(process.env.CODEX_CONTEXT_WINDOW, 10) } : {}),
+    ...(entry ?? {}),
+  };
+  return Object.keys(cfg).length > 0 ? cfg : undefined;
+}
+
 // --- Single-bot env var mode ---
 
 function feishuBotFromEnv(): BotConfig {
+  const codex = buildCodexConfig();
   return {
     name: 'default',
+    ...(process.env.METABOT_ENGINE ? { engine: process.env.METABOT_ENGINE as EngineName } : {}),
+    ...(codex ? { codex } : {}),
     feishu: {
       appId: required('FEISHU_APP_ID'),
       appSecret: required('FEISHU_APP_SECRET'),
@@ -364,8 +420,11 @@ function feishuBotFromEnv(): BotConfig {
 }
 
 function telegramBotFromEnv(): TelegramBotConfig {
+  const codex = buildCodexConfig();
   return {
     name: 'telegram-default',
+    ...(process.env.METABOT_ENGINE ? { engine: process.env.METABOT_ENGINE as EngineName } : {}),
+    ...(codex ? { codex } : {}),
     telegram: {
       botToken: required('TELEGRAM_BOT_TOKEN'),
     },
@@ -384,8 +443,11 @@ function telegramBotFromEnv(): TelegramBotConfig {
 }
 
 function wechatBotFromEnv(): WechatBotConfig {
+  const codex = buildCodexConfig();
   return {
     name: 'wechat-default',
+    ...(process.env.METABOT_ENGINE ? { engine: process.env.METABOT_ENGINE as EngineName } : {}),
+    ...(codex ? { codex } : {}),
     wechat: {
       botToken: process.env.WECHAT_BOT_TOKEN || undefined,
     },

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -6,6 +6,8 @@ import type { EngineName } from '../types.js';
 
 export interface UserSession {
   sessionId: string | undefined;
+  /** Engine that owns sessionId. Engine session stores are not interchangeable. */
+  sessionIdEngine?: EngineName;
   workingDirectory: string;
   lastUsed: number;
   /** Cumulative token usage across all queries in this session */
@@ -16,18 +18,22 @@ export interface UserSession {
   cumulativeDurationMs: number;
   /** Per-session model override (e.g. "claude-opus-4-7"). Falls back to bot default when undefined. */
   model?: string;
-  /** Per-session engine override ("claude" | "kimi"). Falls back to bot default when undefined. */
+  /** Engine that owns model. Model names are engine-specific. */
+  modelEngine?: EngineName;
+  /** Per-session engine override. Falls back to bot default when undefined. */
   engine?: EngineName;
 }
 
 interface PersistedSession {
   sessionId: string;
+  sessionIdEngine?: EngineName;
   workingDirectory: string;
   lastUsed: number;
   cumulativeTokens?: number;
   cumulativeCostUsd?: number;
   cumulativeDurationMs?: number;
   model?: string;
+  modelEngine?: EngineName;
   engine?: EngineName;
 }
 
@@ -92,18 +98,20 @@ export class SessionManager {
     }
   }
 
-  setSessionId(chatId: string, sessionId: string): void {
+  setSessionId(chatId: string, sessionId: string, engine?: EngineName): void {
     const session = this.getSession(chatId);
     session.sessionId = sessionId;
-    this.logger.debug({ chatId, sessionId: sessionId.slice(0, 8) }, 'Session ID updated');
+    session.sessionIdEngine = engine;
+    this.logger.debug({ chatId, sessionId: sessionId.slice(0, 8), engine }, 'Session ID updated');
     this.saveToDisk();
   }
 
   /** Set per-session model override. Pass undefined to clear. */
-  setSessionModel(chatId: string, model: string | undefined): void {
+  setSessionModel(chatId: string, model: string | undefined, engine?: EngineName): void {
     const session = this.getSession(chatId);
     session.model = model;
-    this.logger.info({ chatId, model }, 'Session model override updated');
+    session.modelEngine = model ? engine : undefined;
+    this.logger.info({ chatId, model, engine: session.modelEngine }, 'Session model override updated');
     this.saveToDisk();
   }
 
@@ -118,7 +126,9 @@ export class SessionManager {
     if (session.engine === engine) return;
     session.engine = engine;
     session.sessionId = undefined;
+    session.sessionIdEngine = undefined;
     session.model = undefined;
+    session.modelEngine = undefined;
     this.logger.info({ chatId, engine }, 'Session engine override updated (session reset)');
     this.saveToDisk();
   }
@@ -136,6 +146,7 @@ export class SessionManager {
     const session = this.sessions.get(chatId);
     if (session) {
       session.sessionId = undefined;
+      session.sessionIdEngine = undefined;
       session.cumulativeTokens = 0;
       session.cumulativeCostUsd = 0;
       session.cumulativeDurationMs = 0;
@@ -168,12 +179,14 @@ export class SessionManager {
         if (session.sessionId || session.model || session.engine) {
           data[chatId] = {
             sessionId: session.sessionId || '',
+            sessionIdEngine: session.sessionIdEngine,
             workingDirectory: session.workingDirectory,
             lastUsed: session.lastUsed,
             cumulativeTokens: session.cumulativeTokens,
             cumulativeCostUsd: session.cumulativeCostUsd,
             cumulativeDurationMs: session.cumulativeDurationMs,
             model: session.model,
+            modelEngine: session.modelEngine,
             engine: session.engine,
           };
         }
@@ -196,12 +209,14 @@ export class SessionManager {
         if (now - persisted.lastUsed > SESSION_TTL_MS) continue;
         this.sessions.set(chatId, {
           sessionId: persisted.sessionId || undefined,
+          sessionIdEngine: persisted.sessionIdEngine,
           workingDirectory: persisted.workingDirectory,
           lastUsed: persisted.lastUsed,
           cumulativeTokens: persisted.cumulativeTokens ?? 0,
           cumulativeCostUsd: persisted.cumulativeCostUsd ?? 0,
           cumulativeDurationMs: persisted.cumulativeDurationMs ?? 0,
           model: persisted.model,
+          modelEngine: persisted.modelEngine,
           engine: persisted.engine,
         });
         loaded++;

--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -1,0 +1,219 @@
+import { execSync, spawn, type ChildProcess } from 'node:child_process';
+import type { BotConfigBase } from '../../config.js';
+import type { Logger } from '../../utils/logger.js';
+import { AsyncQueue } from '../../utils/async-queue.js';
+import type {
+  ApiContext,
+  ExecutionHandle,
+  ExecutorOptions,
+  SDKMessage,
+} from '../claude/executor.js';
+import {
+  createCodexTranslatorState,
+  translateCodexJsonEvent,
+  type CodexJsonEvent,
+} from './jsonl-translator.js';
+
+const isWindows = process.platform === 'win32';
+
+function resolveCodexPath(): string {
+  if (process.env.CODEX_EXECUTABLE_PATH) return process.env.CODEX_EXECUTABLE_PATH;
+  try {
+    const cmd = isWindows ? 'where codex' : 'which codex';
+    return execSync(cmd, { encoding: 'utf-8' }).trim().split(/\r?\n/)[0];
+  } catch {
+    return isWindows ? 'codex' : '/usr/local/bin/codex';
+  }
+}
+
+const CODEX_EXECUTABLE = resolveCodexPath();
+
+export class CodexExecutor {
+  constructor(
+    private config: BotConfigBase,
+    private logger: Logger,
+  ) {}
+
+  startExecution(options: ExecutorOptions): ExecutionHandle {
+    const { prompt, cwd, sessionId, abortController, outputsDir, apiContext } = options;
+    const codexConfig = this.config.codex ?? {};
+    const model = options.model ?? codexConfig.model;
+    const fullPrompt = this.buildPromptWithContext(prompt, outputsDir, apiContext);
+    const queue = new AsyncQueue<SDKMessage>();
+    const state = createCodexTranslatorState({
+      model: model || codexConfig.displayModel,
+      contextWindow: codexConfig.contextWindow,
+    });
+    const args = this.buildArgs(cwd, fullPrompt, sessionId, model);
+    const startTime = Date.now();
+    let child: ChildProcess | undefined;
+    let sawResult = false;
+    let stderr = '';
+    let stdoutBuffer = '';
+
+    this.logger.info({ cwd, hasSession: !!sessionId, outputsDir, engine: 'codex' }, 'Starting Codex execution');
+
+    const finishWithError = (message: string): void => {
+      if (sawResult) return;
+      sawResult = true;
+      queue.enqueue({
+        type: 'result',
+        subtype: abortController.signal.aborted ? 'error_cancelled' : 'error_during_execution',
+        session_id: state.sessionId ?? sessionId,
+        duration_ms: Date.now() - startTime,
+        result: state.lastAgentText,
+        is_error: true,
+        errors: [message],
+      });
+    };
+
+    const emitEvent = (event: CodexJsonEvent): void => {
+      const messages = translateCodexJsonEvent(event, state);
+      for (const message of messages) {
+        if (message.type === 'result') sawResult = true;
+        queue.enqueue(message);
+      }
+    };
+
+    const processStdout = (chunk: Buffer): void => {
+      stdoutBuffer += chunk.toString('utf-8');
+      const lines = stdoutBuffer.split(/\r?\n/);
+      stdoutBuffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          emitEvent(JSON.parse(line) as CodexJsonEvent);
+        } catch (err) {
+          this.logger.warn({ err, line }, 'Failed to parse Codex JSONL event');
+        }
+      }
+    };
+
+    try {
+      child = spawn(codexConfig.executable || CODEX_EXECUTABLE, args, {
+        cwd,
+        env: { ...process.env, ...(codexConfig.env ?? {}) },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err: any) {
+      finishWithError(err?.message || String(err));
+      queue.finish();
+    }
+
+    if (child) {
+      if (abortController.signal.aborted) {
+        child.kill('SIGTERM');
+      } else {
+        abortController.signal.addEventListener('abort', () => child?.kill('SIGTERM'), { once: true });
+      }
+
+      child.stdout?.on('data', processStdout);
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8');
+      });
+      child.on('error', (err) => {
+        finishWithError(err.message);
+        queue.finish();
+      });
+      child.on('close', (code, signal) => {
+        if (stdoutBuffer.trim()) {
+          try {
+            emitEvent(JSON.parse(stdoutBuffer) as CodexJsonEvent);
+          } catch (err) {
+            this.logger.warn({ err, line: stdoutBuffer }, 'Failed to parse final Codex JSONL event');
+          }
+        }
+        if (code !== 0 && !sawResult) {
+          const suffix = stderr.trim() ? `: ${stderr.trim()}` : '';
+          finishWithError(`Codex exited with ${signal ? `signal ${signal}` : `code ${code}`}${suffix}`);
+        }
+        if (stderr.trim()) {
+          this.logger.debug({ stderr: stderr.trim() }, 'Codex stderr');
+        }
+        queue.finish();
+      });
+    }
+
+    return {
+      stream: queue[Symbol.asyncIterator]() as AsyncGenerator<SDKMessage>,
+      sendAnswer: (_toolUseId: string, _sid: string, _answerText: string) => {
+        this.logger.warn({ engine: 'codex' }, 'sendAnswer called on Codex executor — not implemented');
+      },
+      resolveQuestion: (_toolUseId: string, _answers: Record<string, string>) => {
+        this.logger.warn({ engine: 'codex' }, 'resolveQuestion called on Codex executor — not implemented');
+      },
+      finish: () => {
+        if (child && !child.killed) child.kill('SIGTERM');
+        queue.finish();
+      },
+    };
+  }
+
+  async *execute(options: ExecutorOptions): AsyncGenerator<SDKMessage> {
+    const handle = this.startExecution(options);
+    try {
+      for await (const msg of handle.stream) {
+        yield msg;
+      }
+    } finally {
+      handle.finish();
+    }
+  }
+
+  private buildArgs(cwd: string, prompt: string, sessionId: string | undefined, model: string | undefined): string[] {
+    const codexConfig = this.config.codex ?? {};
+    const args: string[] = [];
+
+    if (codexConfig.dangerouslyBypassApprovalsAndSandbox) {
+      args.push('--dangerously-bypass-approvals-and-sandbox');
+    } else {
+      args.push('-a', codexConfig.approvalPolicy ?? 'never');
+      args.push('--sandbox', codexConfig.sandbox ?? 'workspace-write');
+    }
+
+    args.push('-C', cwd);
+    if (model) args.push('-m', model);
+    if (codexConfig.profile) args.push('-p', codexConfig.profile);
+    for (const extraArg of codexConfig.extraArgs ?? []) args.push(extraArg);
+
+    args.push('exec');
+    if (sessionId) {
+      args.push('resume', '--json', '--skip-git-repo-check', sessionId, prompt);
+    } else {
+      args.push('--json', '--color', 'never', '--skip-git-repo-check', prompt);
+    }
+    return args;
+  }
+
+  private buildPromptWithContext(
+    prompt: string,
+    outputsDir: string | undefined,
+    apiContext: ApiContext | undefined,
+  ): string {
+    const sections: string[] = [];
+
+    if (outputsDir) {
+      sections.push(
+        `## Output Files\nWhen producing output files for the user (images, PDFs, documents, archives, code files, etc.), copy them to: ${outputsDir}\nThe bridge will automatically send files placed there to the user.`,
+      );
+    }
+
+    if (apiContext) {
+      sections.push(
+        `## MetaBot API\nYou are running as bot "${apiContext.botName}" in chat "${apiContext.chatId}".\nUse the /metabot skill for full API documentation (agent bus, scheduling, bot management).`,
+      );
+
+      if (apiContext.groupMembers && apiContext.groupMembers.length > 0) {
+        const others = apiContext.groupMembers.filter((m) => m !== apiContext.botName);
+        if (apiContext.groupId) {
+          sections.push(
+            `## Group Chat\nYou are in a group chat (group: ${apiContext.groupId}) with these bots: ${others.join(', ')}.\nTo talk to another bot, use: \`mb talk <botName> grouptalk-${apiContext.groupId}-<botName> "message"\``,
+          );
+        }
+      }
+    }
+
+    if (sections.length === 0) return prompt;
+    return `${prompt}\n\n---\n\n${sections.join('\n\n')}`;
+  }
+}

--- a/src/engines/codex/executor.ts
+++ b/src/engines/codex/executor.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
-import type { BotConfigBase } from '../../config.js';
+import type { BotConfigBase, CodexBotConfig } from '../../config.js';
 import type { Logger } from '../../utils/logger.js';
 import { AsyncQueue } from '../../utils/async-queue.js';
 import type {
@@ -28,6 +28,43 @@ function resolveCodexPath(): string {
 
 const CODEX_EXECUTABLE = resolveCodexPath();
 
+/**
+ * Build the argv array for `codex exec`. Exported for unit testing.
+ * Values are passed as discrete argv entries (never through a shell), so
+ * `extraArgs` / `profile` / `model` cannot introduce shell-injection even
+ * if they contain metacharacters — but they will still be visible to the
+ * Codex CLI as literal arguments.
+ */
+export function buildCodexArgs(
+  codexConfig: CodexBotConfig,
+  cwd: string,
+  prompt: string,
+  sessionId: string | undefined,
+  model: string | undefined,
+): string[] {
+  const args: string[] = [];
+
+  if (codexConfig.dangerouslyBypassApprovalsAndSandbox) {
+    args.push('--dangerously-bypass-approvals-and-sandbox');
+  } else {
+    args.push('-a', codexConfig.approvalPolicy ?? 'never');
+    args.push('--sandbox', codexConfig.sandbox ?? 'workspace-write');
+  }
+
+  args.push('-C', cwd);
+  if (model) args.push('-m', model);
+  if (codexConfig.profile) args.push('-p', codexConfig.profile);
+  for (const extraArg of codexConfig.extraArgs ?? []) args.push(extraArg);
+
+  args.push('exec');
+  if (sessionId) {
+    args.push('resume', '--json', '--skip-git-repo-check', sessionId, prompt);
+  } else {
+    args.push('--json', '--color', 'never', '--skip-git-repo-check', prompt);
+  }
+  return args;
+}
+
 export class CodexExecutor {
   constructor(
     private config: BotConfigBase,
@@ -44,7 +81,7 @@ export class CodexExecutor {
       model: model || codexConfig.displayModel,
       contextWindow: codexConfig.contextWindow,
     });
-    const args = this.buildArgs(cwd, fullPrompt, sessionId, model);
+    const args = buildCodexArgs(codexConfig, cwd, fullPrompt, sessionId, model);
     const startTime = Date.now();
     let child: ChildProcess | undefined;
     let sawResult = false;
@@ -158,31 +195,6 @@ export class CodexExecutor {
     } finally {
       handle.finish();
     }
-  }
-
-  private buildArgs(cwd: string, prompt: string, sessionId: string | undefined, model: string | undefined): string[] {
-    const codexConfig = this.config.codex ?? {};
-    const args: string[] = [];
-
-    if (codexConfig.dangerouslyBypassApprovalsAndSandbox) {
-      args.push('--dangerously-bypass-approvals-and-sandbox');
-    } else {
-      args.push('-a', codexConfig.approvalPolicy ?? 'never');
-      args.push('--sandbox', codexConfig.sandbox ?? 'workspace-write');
-    }
-
-    args.push('-C', cwd);
-    if (model) args.push('-m', model);
-    if (codexConfig.profile) args.push('-p', codexConfig.profile);
-    for (const extraArg of codexConfig.extraArgs ?? []) args.push(extraArg);
-
-    args.push('exec');
-    if (sessionId) {
-      args.push('resume', '--json', '--skip-git-repo-check', sessionId, prompt);
-    } else {
-      args.push('--json', '--color', 'never', '--skip-git-repo-check', prompt);
-    }
-    return args;
   }
 
   private buildPromptWithContext(

--- a/src/engines/codex/index.ts
+++ b/src/engines/codex/index.ts
@@ -1,0 +1,29 @@
+import type { BotConfigBase } from '../../config.js';
+import type { Logger } from '../../utils/logger.js';
+import type { Engine } from '../types.js';
+import { StreamProcessor } from '../claude/stream-processor.js';
+import { CodexExecutor } from './executor.js';
+
+export class CodexEngine implements Engine {
+  readonly name = 'codex' as const;
+
+  constructor(
+    private config: BotConfigBase,
+    private logger: Logger,
+  ) {}
+
+  createExecutor(): CodexExecutor {
+    return new CodexExecutor(this.config, this.logger);
+  }
+
+  createStreamProcessor(userPrompt: string): StreamProcessor {
+    return new StreamProcessor(userPrompt);
+  }
+}
+
+export { CodexExecutor } from './executor.js';
+export {
+  createCodexTranslatorState,
+  translateCodexJsonEvent,
+} from './jsonl-translator.js';
+export type { CodexJsonEvent, CodexTranslatorState } from './jsonl-translator.js';

--- a/src/engines/codex/jsonl-translator.ts
+++ b/src/engines/codex/jsonl-translator.ts
@@ -1,0 +1,155 @@
+import type { SDKMessage } from '../claude/executor.js';
+
+export interface CodexTranslatorState {
+  sessionId?: string;
+  lastAgentText: string;
+  startTime: number;
+  model?: string;
+  contextWindow?: number;
+}
+
+export interface CodexJsonEvent {
+  type: string;
+  thread_id?: string;
+  item?: CodexItem;
+  usage?: CodexUsage;
+  error?: { message?: string };
+  message?: string;
+}
+
+export interface CodexUsage {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+}
+
+export type CodexItem =
+  | { id: string; type: 'agent_message'; text?: string }
+  | {
+      id: string;
+      type: 'command_execution';
+      command?: string;
+      aggregated_output?: string;
+      exit_code?: number | null;
+      status?: string;
+    }
+  | { id: string; type: string; [key: string]: unknown };
+
+export function createCodexTranslatorState(options: {
+  model?: string;
+  contextWindow?: number;
+} = {}): CodexTranslatorState {
+  return {
+    lastAgentText: '',
+    startTime: Date.now(),
+    model: options.model,
+    contextWindow: options.contextWindow,
+  };
+}
+
+export function translateCodexJsonEvent(
+  event: CodexJsonEvent,
+  state: CodexTranslatorState,
+): SDKMessage[] {
+  switch (event.type) {
+    case 'thread.started':
+      if (!event.thread_id) return [];
+      state.sessionId = event.thread_id;
+      return [{ type: 'system', subtype: 'init', session_id: event.thread_id }];
+
+    case 'item.started':
+      if (!event.item) return [];
+      return translateStartedItem(event.item, state);
+
+    case 'item.completed':
+      if (!event.item) return [];
+      return translateCompletedItem(event.item, state);
+
+    case 'turn.completed':
+      return [buildResultMessage(event.usage, state, false)];
+
+    case 'turn.failed':
+      return [buildResultMessage(undefined, state, true, event.error?.message)];
+
+    case 'error':
+      return event.message
+        ? [{ type: 'task_notification', session_id: state.sessionId, result: event.message }]
+        : [];
+
+    default:
+      return [];
+  }
+}
+
+function translateStartedItem(item: CodexItem, state: CodexTranslatorState): SDKMessage[] {
+  if (item.type !== 'command_execution') return [];
+  return [{
+    type: 'assistant',
+    session_id: state.sessionId,
+    message: {
+      content: [{
+        type: 'tool_use',
+        id: item.id,
+        name: 'Bash',
+        input: { command: typeof item.command === 'string' ? item.command : '' },
+      }],
+    },
+  }];
+}
+
+function translateCompletedItem(item: CodexItem, state: CodexTranslatorState): SDKMessage[] {
+  if (item.type === 'agent_message') {
+    const text = typeof item.text === 'string' ? item.text : '';
+    state.lastAgentText = text;
+    return [{
+      type: 'assistant',
+      session_id: state.sessionId,
+      message: { content: [{ type: 'text', text }] },
+    }];
+  }
+
+  if (item.type === 'command_execution') {
+    return [{
+      type: 'user',
+      session_id: state.sessionId,
+      message: {
+        content: [{
+          type: 'tool_result',
+          id: item.id,
+          text: typeof item.aggregated_output === 'string' ? item.aggregated_output : '',
+        }],
+      },
+    }];
+  }
+
+  return [];
+}
+
+function buildResultMessage(
+  usage: CodexUsage | undefined,
+  state: CodexTranslatorState,
+  isError: boolean,
+  errorMessage?: string,
+): SDKMessage {
+  const modelUsage = state.model
+    ? {
+        [state.model]: {
+          inputTokens: usage?.input_tokens ?? 0,
+          outputTokens: usage?.output_tokens ?? 0,
+          contextWindow: state.contextWindow ?? 0,
+          costUSD: 0,
+        },
+      }
+    : undefined;
+
+  return {
+    type: 'result',
+    subtype: isError ? 'error_during_execution' : 'success',
+    session_id: state.sessionId,
+    duration_ms: Date.now() - state.startTime,
+    result: state.lastAgentText,
+    is_error: isError,
+    errors: isError ? [errorMessage || 'Codex execution failed'] : undefined,
+    modelUsage,
+  };
+}

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -3,6 +3,7 @@ import type { Logger } from '../utils/logger.js';
 import type { Engine, EngineName } from './types.js';
 import { ClaudeEngine } from './claude/index.js';
 import { KimiEngine } from './kimi/index.js';
+import { CodexEngine } from './codex/index.js';
 
 /**
  * Create an Engine for the given bot config.
@@ -24,7 +25,7 @@ export function createEngine(
     case 'kimi':
       return new KimiEngine(config, logger);
     case 'codex':
-      throw new Error("Engine 'codex' is not yet implemented (lands in Batch 4).");
+      return new CodexEngine(config, logger);
     default: {
       const _exhaustive: never = name;
       throw new Error(`Unknown engine: ${_exhaustive}`);
@@ -44,6 +45,7 @@ export function resolveEngineName(config: BotConfigBase): EngineName {
 export type { Engine, EngineName, Executor } from './types.js';
 export { ClaudeEngine } from './claude/index.js';
 export { KimiEngine } from './kimi/index.js';
+export { CodexEngine } from './codex/index.js';
 
 // Re-export shared types and classes currently used by the bridge and web/api layers.
 // Moving these behind the engine boundary lets consumers import from a single place.

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -7,6 +7,7 @@ import type {
   SDKMessage,
   ApiContext,
 } from './claude/executor.js';
+import type { CodexExecutor } from './codex/executor.js';
 import type { StreamProcessor } from './claude/stream-processor.js';
 
 export type EngineName = 'claude' | 'kimi' | 'codex';
@@ -43,6 +44,7 @@ export type StreamProcessorLike = StreamProcessor;
 
 export type {
   ClaudeExecutor,
+  CodexExecutor,
   ExecutionHandle,
   ExecutorOptions,
   SDKMessage,

--- a/tests/codex-build-args.test.ts
+++ b/tests/codex-build-args.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { buildCodexArgs } from '../src/engines/codex/executor.js';
+import type { CodexBotConfig } from '../src/config.js';
+
+describe('buildCodexArgs', () => {
+  const cwd = '/work/proj';
+  const prompt = 'run pwd';
+
+  it('defaults approval policy to "never" and sandbox to "workspace-write"', () => {
+    const args = buildCodexArgs({}, cwd, prompt, undefined, undefined);
+    expect(args).toEqual([
+      '-a', 'never',
+      '--sandbox', 'workspace-write',
+      '-C', cwd,
+      'exec', '--json', '--color', 'never', '--skip-git-repo-check', prompt,
+    ]);
+  });
+
+  it('honors explicit approvalPolicy and sandbox', () => {
+    const cfg: CodexBotConfig = { approvalPolicy: 'on-failure', sandbox: 'read-only' };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, undefined);
+    expect(args.slice(0, 4)).toEqual(['-a', 'on-failure', '--sandbox', 'read-only']);
+  });
+
+  it('replaces policy/sandbox flags when dangerouslyBypassApprovalsAndSandbox is set', () => {
+    const cfg: CodexBotConfig = {
+      dangerouslyBypassApprovalsAndSandbox: true,
+      approvalPolicy: 'on-failure',
+      sandbox: 'read-only',
+    };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, undefined);
+    expect(args[0]).toBe('--dangerously-bypass-approvals-and-sandbox');
+    expect(args).not.toContain('-a');
+    expect(args).not.toContain('--sandbox');
+  });
+
+  it('passes model and profile when provided', () => {
+    const cfg: CodexBotConfig = { profile: 'staging' };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, 'gpt-5.4-codex');
+    expect(args).toContain('-m');
+    expect(args[args.indexOf('-m') + 1]).toBe('gpt-5.4-codex');
+    expect(args).toContain('-p');
+    expect(args[args.indexOf('-p') + 1]).toBe('staging');
+  });
+
+  it('appends extraArgs verbatim between global flags and the exec subcommand', () => {
+    const cfg: CodexBotConfig = { extraArgs: ['--foo', 'bar baz', '--qux'] };
+    const args = buildCodexArgs(cfg, cwd, prompt, undefined, undefined);
+    const execIdx = args.indexOf('exec');
+    expect(args.slice(execIdx - 3, execIdx)).toEqual(['--foo', 'bar baz', '--qux']);
+  });
+
+  it('uses `exec resume <sessionId>` when a session id is provided', () => {
+    const args = buildCodexArgs({}, cwd, prompt, 'sess-abc', undefined);
+    const tail = args.slice(args.indexOf('exec'));
+    expect(tail).toEqual(['exec', 'resume', '--json', '--skip-git-repo-check', 'sess-abc', prompt]);
+    // resume path does NOT pass --color never (Codex resume subcommand differs)
+    expect(tail).not.toContain('--color');
+  });
+
+  it('passes `--color never` for fresh executions (no session id)', () => {
+    const args = buildCodexArgs({}, cwd, prompt, undefined, undefined);
+    const tail = args.slice(args.indexOf('exec'));
+    expect(tail).toEqual(['exec', '--json', '--color', 'never', '--skip-git-repo-check', prompt]);
+  });
+
+  it('keeps prompt as a single argv entry even with whitespace / metacharacters', () => {
+    // spawn() receives argv as an array, so shell metacharacters are safe.
+    const evil = 'ignore; rm -rf /\n`whoami`';
+    const args = buildCodexArgs({}, cwd, evil, undefined, undefined);
+    expect(args[args.length - 1]).toBe(evil);
+  });
+});

--- a/tests/codex-jsonl-translator.test.ts
+++ b/tests/codex-jsonl-translator.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { StreamProcessor } from '../src/engines/claude/stream-processor.js';
+import {
+  createCodexTranslatorState,
+  translateCodexJsonEvent,
+  type CodexJsonEvent,
+} from '../src/engines/codex/jsonl-translator.js';
+
+describe('Codex JSONL translator', () => {
+  it('maps Codex exec events into the existing stream processor shape', () => {
+    const events: CodexJsonEvent[] = [
+      { type: 'thread.started', thread_id: '019dbe98-98b1-78b1-a6b0-b422e495db52' },
+      { type: 'turn.started' },
+      {
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'agent_message', text: 'I’ll run `pwd` once.' },
+      },
+      {
+        type: 'item.started',
+        item: {
+          id: 'item_1',
+          type: 'command_execution',
+          command: '/bin/zsh -lc pwd',
+          aggregated_output: '',
+          exit_code: null,
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'item.completed',
+        item: {
+          id: 'item_1',
+          type: 'command_execution',
+          command: '/bin/zsh -lc pwd',
+          aggregated_output: '/Users/maxzhou/Dev/metabot\n',
+          exit_code: 0,
+          status: 'completed',
+        },
+      },
+      { type: 'item.completed', item: { id: 'item_2', type: 'agent_message', text: 'DONE' } },
+      { type: 'turn.completed', usage: { input_tokens: 23111, cached_input_tokens: 12800, output_tokens: 70 } },
+    ];
+
+    const state = createCodexTranslatorState({ model: 'gpt-5.4-codex', contextWindow: 400000 });
+    const processor = new StreamProcessor('Run pwd');
+
+    let cardState = processor.processMessage({ type: 'system' });
+    for (const event of events) {
+      for (const message of translateCodexJsonEvent(event, state)) {
+        cardState = processor.processMessage(message);
+      }
+    }
+
+    expect(processor.getSessionId()).toBe('019dbe98-98b1-78b1-a6b0-b422e495db52');
+    expect(cardState.status).toBe('complete');
+    expect(cardState.responseText).toBe('DONE');
+    expect(cardState.toolCalls).toEqual([{ name: 'Bash', detail: '`/bin/zsh -lc pwd`', status: 'done' }]);
+    expect(cardState.model).toBe('gpt-5.4-codex');
+    expect(cardState.totalTokens).toBe(23181);
+    expect(cardState.contextWindow).toBe(400000);
+  });
+
+  it('maps failed turns to error results', () => {
+    const state = createCodexTranslatorState();
+    const processor = new StreamProcessor('hello');
+
+    for (const message of translateCodexJsonEvent({ type: 'thread.started', thread_id: 'codex-thread' }, state)) {
+      processor.processMessage(message);
+    }
+    let cardState = processor.processMessage({ type: 'system' });
+    for (const message of translateCodexJsonEvent({ type: 'turn.failed', error: { message: 'network failed' } }, state)) {
+      cardState = processor.processMessage(message);
+    }
+
+    expect(cardState.status).toBe('error');
+    expect(cardState.errorMessage).toBe('network failed');
+  });
+});

--- a/tests/codex-jsonl-translator.test.ts
+++ b/tests/codex-jsonl-translator.test.ts
@@ -75,4 +75,61 @@ describe('Codex JSONL translator', () => {
     expect(cardState.status).toBe('error');
     expect(cardState.errorMessage).toBe('network failed');
   });
+
+  it('captures session id from thread.started and leaves state empty otherwise', () => {
+    const state = createCodexTranslatorState();
+    expect(state.sessionId).toBeUndefined();
+
+    const messages = translateCodexJsonEvent({ type: 'thread.started', thread_id: 'sid-1' }, state);
+    expect(state.sessionId).toBe('sid-1');
+    expect(messages).toEqual([{ type: 'system', subtype: 'init', session_id: 'sid-1' }]);
+  });
+
+  it('ignores thread.started without a thread_id (defensive)', () => {
+    const state = createCodexTranslatorState();
+    const messages = translateCodexJsonEvent({ type: 'thread.started' } as CodexJsonEvent, state);
+    expect(messages).toEqual([]);
+    expect(state.sessionId).toBeUndefined();
+  });
+
+  it('returns [] for unknown / unhandled event types', () => {
+    const state = createCodexTranslatorState();
+    expect(translateCodexJsonEvent({ type: 'turn.started' }, state)).toEqual([]);
+    expect(translateCodexJsonEvent({ type: 'something.new' } as CodexJsonEvent, state)).toEqual([]);
+  });
+
+  it('emits a task_notification message for top-level Codex error events with a message', () => {
+    const state = createCodexTranslatorState();
+    state.sessionId = 'sid-err';
+    const messages = translateCodexJsonEvent({ type: 'error', message: 'ratelimited' }, state);
+    expect(messages).toEqual([
+      { type: 'task_notification', session_id: 'sid-err', result: 'ratelimited' },
+    ]);
+  });
+
+  it('drops error events that carry no message', () => {
+    const state = createCodexTranslatorState();
+    expect(translateCodexJsonEvent({ type: 'error' }, state)).toEqual([]);
+  });
+
+  it('tolerates item.completed agent_message with missing text', () => {
+    const state = createCodexTranslatorState();
+    const messages = translateCodexJsonEvent(
+      { type: 'item.completed', item: { id: 'x', type: 'agent_message' } } as CodexJsonEvent,
+      state,
+    );
+    expect(state.lastAgentText).toBe('');
+    expect(messages[0]).toMatchObject({ type: 'assistant' });
+  });
+
+  it('falls back to a generic failure message when turn.failed has no error detail', () => {
+    const state = createCodexTranslatorState();
+    const [msg] = translateCodexJsonEvent({ type: 'turn.failed' }, state);
+    expect(msg).toMatchObject({
+      type: 'result',
+      is_error: true,
+      subtype: 'error_during_execution',
+      errors: ['Codex execution failed'],
+    });
+  });
 });

--- a/tests/codex-jsonl-translator.test.ts
+++ b/tests/codex-jsonl-translator.test.ts
@@ -44,17 +44,26 @@ describe('Codex JSONL translator', () => {
     const state = createCodexTranslatorState({ model: 'gpt-5.4-codex', contextWindow: 400000 });
     const processor = new StreamProcessor('Run pwd');
 
+    // Fork's StreamProcessor splits each assistant text into a per-turn message
+    // (drained via completedTurnText) instead of accumulating into responseText.
+    // Collect the emitted turns so the test reflects the fork's send-on-each-turn
+    // semantics rather than upstream's accumulate-into-responseText behavior.
+    const turnTexts: string[] = [];
     let cardState = processor.processMessage({ type: 'system' });
+    if (cardState.completedTurnText) turnTexts.push(cardState.completedTurnText);
     for (const event of events) {
       for (const message of translateCodexJsonEvent(event, state)) {
         cardState = processor.processMessage(message);
+        if (cardState.completedTurnText) turnTexts.push(cardState.completedTurnText);
       }
     }
 
     expect(processor.getSessionId()).toBe('019dbe98-98b1-78b1-a6b0-b422e495db52');
     expect(cardState.status).toBe('complete');
-    expect(cardState.responseText).toBe('DONE');
-    expect(cardState.toolCalls).toEqual([{ name: 'Bash', detail: '`/bin/zsh -lc pwd`', status: 'done' }]);
+    expect(turnTexts).toEqual(['I’ll run `pwd` once.', 'DONE']);
+    expect(cardState.toolCalls).toEqual([
+      { name: 'Bash', detail: '`/bin/zsh -lc pwd`', status: 'done', input: '/bin/zsh -lc pwd' },
+    ]);
     expect(cardState.model).toBe('gpt-5.4-codex');
     expect(cardState.totalTokens).toBe(23181);
     expect(cardState.contextWindow).toBe(400000);

--- a/tests/message-bridge.test.ts
+++ b/tests/message-bridge.test.ts
@@ -13,6 +13,12 @@ describe('isStaleSessionError', () => {
     expect(isStaleSessionError('Conversation not found')).toBe(true);
   });
 
+  it('matches Codex stale thread resume errors', () => {
+    expect(
+      isStaleSessionError('Error: Codex exited with code 1: Error: thread/resume: thread/resume failed: no rollout found for thread id ea0dd6d2-7418-4545-8427-63cc8aed81f2'),
+    ).toBe(true);
+  });
+
   it('matches conversation corruption errors (duplicate tool_result)', () => {
     expect(
       isStaleSessionError('API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.148.content.1: each tool_use must have a single result. Found multiple `tool_result` blocks with id: toolu_01TPsHXcmpuz5cAY97fM5vXv"}}'),

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SessionManager } from '../src/engines/claude/session-manager.js';
 
 function createLogger() {
@@ -7,9 +10,17 @@ function createLogger() {
 
 describe('SessionManager', () => {
   let manager: SessionManager;
+  let storeDir: string;
+
+  beforeEach(() => {
+    storeDir = mkdtempSync(join(tmpdir(), 'metabot-session-test-'));
+    process.env.SESSION_STORE_DIR = storeDir;
+  });
 
   afterEach(() => {
     if (manager) manager.destroy();
+    delete process.env.SESSION_STORE_DIR;
+    rmSync(storeDir, { recursive: true, force: true });
   });
 
   it('creates a new session with default working directory', () => {
@@ -36,17 +47,47 @@ describe('SessionManager', () => {
   it('sets session ID', () => {
     manager = new SessionManager('/tmp/test-dir', createLogger());
     manager.getSession('chat1');
-    manager.setSessionId('chat1', 'sess-abc');
+    manager.setSessionId('chat1', 'sess-abc', 'codex');
     const session = manager.getSession('chat1');
     expect(session.sessionId).toBe('sess-abc');
+    expect(session.sessionIdEngine).toBe('codex');
   });
 
   it('resets session (clears sessionId)', () => {
     manager = new SessionManager('/tmp/test-dir', createLogger());
     manager.getSession('chat1');
-    manager.setSessionId('chat1', 'sess-abc');
+    manager.setSessionId('chat1', 'sess-abc', 'codex');
     manager.resetSession('chat1');
     const session = manager.getSession('chat1');
     expect(session.sessionId).toBeUndefined();
+    expect(session.sessionIdEngine).toBeUndefined();
+  });
+
+  it('tracks model engine and clears it with the model override', () => {
+    manager = new SessionManager('/tmp/test-dir', createLogger());
+    manager.setSessionModel('chat1', 'gpt-5.5-codex', 'codex');
+
+    let session = manager.getSession('chat1');
+    expect(session.model).toBe('gpt-5.5-codex');
+    expect(session.modelEngine).toBe('codex');
+
+    manager.setSessionModel('chat1', undefined);
+    session = manager.getSession('chat1');
+    expect(session.model).toBeUndefined();
+    expect(session.modelEngine).toBeUndefined();
+  });
+
+  it('persists session and model engine metadata', () => {
+    manager = new SessionManager('/tmp/test-dir', createLogger(), 'persist-test');
+    manager.setSessionId('chat1', 'sess-abc', 'codex');
+    manager.setSessionModel('chat1', 'gpt-5.5-codex', 'codex');
+    manager.destroy();
+
+    manager = new SessionManager('/tmp/test-dir', createLogger(), 'persist-test');
+    const session = manager.getSession('chat1');
+    expect(session.sessionId).toBe('sess-abc');
+    expect(session.sessionIdEngine).toBe('codex');
+    expect(session.model).toBe('gpt-5.5-codex');
+    expect(session.modelEngine).toBe('codex');
   });
 });

--- a/web/src/components/BotManageDialog.tsx
+++ b/web/src/components/BotManageDialog.tsx
@@ -14,9 +14,10 @@ export function BotManageDialog({ mode, bot, onClose }: BotManageDialogProps) {
 
   const [name, setName] = useState(bot?.name || '');
   const [platform, setPlatform] = useState(bot?.platform || 'web');
+  const [engine, setEngine] = useState(bot?.engine || 'claude');
   const [workDir, setWorkDir] = useState(bot?.workingDirectory || '');
   const [description, setDescription] = useState(bot?.description || '');
-  const [model, setModel] = useState('');
+  const [model, setModel] = useState(bot?.model || '');
   const [maxTurns, setMaxTurns] = useState('');
   const [maxBudget, setMaxBudget] = useState('');
   const [loading, setLoading] = useState(false);
@@ -34,9 +35,11 @@ export function BotManageDialog({ mode, bot, onClose }: BotManageDialogProps) {
       name: name.trim(),
       platform,
       defaultWorkingDirectory: workDir.trim(),
+      engine,
     };
     if (description.trim()) body.description = description.trim();
     if (model.trim()) body.model = model.trim();
+    if (engine === 'codex' && model.trim()) body.codex = { model: model.trim() };
     if (maxTurns.trim()) body.maxTurns = parseInt(maxTurns, 10);
     if (maxBudget.trim()) body.maxBudgetUsd = parseFloat(maxBudget);
 
@@ -63,7 +66,7 @@ export function BotManageDialog({ mode, bot, onClose }: BotManageDialogProps) {
     } finally {
       setLoading(false);
     }
-  }, [name, platform, workDir, description, model, maxTurns, maxBudget, mode, bot, token, onClose]);
+  }, [name, platform, engine, workDir, description, model, maxTurns, maxBudget, mode, bot, token, onClose]);
 
   return (
     <div className={styles.overlay} onClick={onClose}>
@@ -109,6 +112,19 @@ export function BotManageDialog({ mode, bot, onClose }: BotManageDialogProps) {
           </label>
 
           <label className={styles.field}>
+            <span className={styles.label}>Engine</span>
+            <select
+              className={styles.input}
+              value={engine}
+              onChange={(e) => setEngine(e.target.value as 'claude' | 'kimi' | 'codex')}
+            >
+              <option value="claude">Claude Code</option>
+              <option value="kimi">Kimi Code</option>
+              <option value="codex">Codex CLI</option>
+            </select>
+          </label>
+
+          <label className={styles.field}>
             <span className={styles.label}>Description (optional)</span>
             <input
               className={styles.input}
@@ -125,7 +141,7 @@ export function BotManageDialog({ mode, bot, onClose }: BotManageDialogProps) {
                 className={styles.input}
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
-                placeholder="claude-opus-4-7"
+                placeholder={engine === 'codex' ? 'gpt-5.4-codex' : engine === 'kimi' ? 'kimi-for-coding' : 'claude-opus-4-7'}
               />
             </label>
             <label className={styles.field}>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -31,6 +31,8 @@ export interface BotStatus {
   specialties?: string[];
   icon?: string;
   platform: string;
+  engine?: 'claude' | 'kimi' | 'codex';
+  model?: string;
   workingDirectory: string;
   status: 'idle' | 'busy' | 'error';
   currentTask?: {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -43,6 +43,8 @@ export interface BotInfo {
   name: string;
   description?: string;
   platform: string;
+  engine?: 'claude' | 'kimi' | 'codex';
+  model?: string;
   workingDirectory: string;
 }
 


### PR DESCRIPTION
Closes #35.

Fourth of five upstream catch-up batches. After this lands the bot supports all three engines: \`claude\` (default), \`kimi\`, \`codex\`.

## Cherry-picked from \`xvirobotics/metabot\`

| upstream PR | what                                                              |
|-------------|-------------------------------------------------------------------|
| #214        | feat: add Codex CLI engine                                        |
| #215        | docs(codex): triple-engine README + tests + prerequisites         |
| #219        | feat(installer): add Codex CLI engine option to install.sh        |
| #237        | Fix Codex resume after engine switch                              |

## Conflicts resolved

- \`src/engines/index.ts\` — replaced the Batch-1 \`case 'codex': throw\` with \`new CodexEngine(...)\`.
- \`src/config.ts\` — kept the merged \`Codex\` type while preserving fork's \`approval?.smartApproval\` block; doc comment widened to mention all three engines.
- \`README.md\` / \`README_EN.md\` — took upstream's redesigned for-the-badge header (already triple-engine aware).
- \`src/bridge/message-bridge.ts\` (#237) — fork's retry-loop structure conflicts heavily with upstream's per-line edits, so kept HEAD wholesale and re-applied #237's four changes by hand: new \`prepareSessionForExecution(chatId)\` helper, both entry points (\`executeQuery\` / \`executeApi\`) call it, all \`setSessionId\` calls now pass \`engineName\`, and \`isStaleSessionError\` regex picks up Codex-specific patterns (\`thread/resume failed\`, \`no rollout found\`).

## Extra commit

- \`d428cc6\` adapts \`tests/codex-jsonl-translator.test.ts\` to the fork's per-turn semantics. Upstream asserts \`responseText === 'DONE'\` after two \`agent_message\` events, but the fork drains each assistant text via \`completedTurnText\` (per-turn message splitting from #3), so \`responseText\` is empty by design. The test now collects emitted turns and verifies the same content through that path.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`npm test\` — 696/696 pass
- [ ] Smoke \`/model codex\` on a Codex-enabled bot (manual, after merge)
- [ ] Smoke engine switch claude → codex resets sessionId (verify via logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)