### PR TITLE
Batch 5: upstream misc fixes + installer DX + session TTL (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `install.sh`: `--dir <path>` / `-d <path>` flag to customize the install directory (priority: `--dir` > `METABOT_HOME` env > interactive prompt > `~/metabot`). Non-default paths are persisted to `~/.bashrc` / `~/.zshrc` so the `mb`/`mm`/`metabot` CLIs find the install in new shells.
+- `install.ps1`: matching `-Dir <path>` parameter on Windows; non-default paths persisted via user-level `METABOT_HOME` environment variable.
 - CONTRIBUTING.md with development setup guide
 - GitHub Actions CI workflow (Node.js 20/22 build + type check)
 - Issue templates for bug reports and feature requests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MetaBot — A bridge service that connects IM bots (Feishu/Lark) to the Claude Code Agent SDK. Users chat with Claude Code from Feishu (including mobile), with real-time streaming updates via interactive cards. Runs Claude in `bypassPermissions` mode since there's no terminal for interactive approval.
+MetaBot — A bridge service that connects IM bots (Feishu/Lark) to the Claude Code Agent SDK. Users chat with Claude Code from Feishu (including mobile), with real-time streaming updates via interactive cards. Runs Claude in `bypassPermissions` mode (or `auto` mode when running as root) since there's no terminal for interactive approval.
 
 ## Commands
 
@@ -344,9 +344,9 @@ This is the step-by-step procedure to configure a Feishu bot for this bridge ser
 
 ### "Error: Claude Code process exited with code 1"
 
-The bot starts but replies with this error when you message it. This means the Agent SDK's subprocess (`claude`) failed to launch properly.
+The bot starts but replies with this error when you message it. This means the Agent SDK's subprocess (`claude`) failed to launch properly. There are two causes:
 
-**Cause**: Claude CLI is not authenticated. The SDK spawns `claude` as a child process — if it has no valid credentials, it exits immediately with code 1.
+**Cause A: Claude CLI is not authenticated.** The SDK spawns `claude` as a child process — if it has no valid credentials, it exits immediately with code 1.
 
 **Fix** (run in a **separate terminal**, not inside Claude Code):
 
@@ -364,6 +364,8 @@ Then restart the service:
 pkill -f "tsx src/index.ts"
 cd /path/to/metabot && npm run dev
 ```
+
+**Cause B: Running as root/sudo.** Claude Code blocks `--dangerously-skip-permissions` under root privileges. Check `pm2 logs metabot` for: `--dangerously-skip-permissions cannot be used with root/sudo privileges`. MetaBot automatically switches to `permissionMode: auto` when it detects root — ensure you're on a version that includes this fix.
 
 ### Service won't connect to Feishu
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh
 
 安装器引导一切：工作目录 → **引擎选择（Claude / Kimi / Codex）** → 订阅登录 → IM 平台 → PM2 自动启动。**5 分钟上手。**
 
+> 自定义安装目录(默认 `~/metabot`)：`curl ... | bash -s -- --dir /opt/metabot`,或 `METABOT_HOME=/opt/metabot bash install.sh`。Windows: `.\install.ps1 -Dir C:\opt\metabot`。
+
 ---
 
 ## 三引擎：Claude Code ✕ Kimi Code ✕ Codex CLI 并列一等支持

--- a/README_EN.md
+++ b/README_EN.md
@@ -42,6 +42,8 @@ curl -fsSL https://raw.githubusercontent.com/xvirobotics/metabot/main/install.sh
 
 The installer walks you through everything: working directory → **engine choice (Claude / Kimi / Codex)** → subscription login → IM platform → auto-start with PM2. **5 minutes to get started.**
 
+> Custom install directory (default `~/metabot`): `curl ... | bash -s -- --dir /opt/metabot`, or `METABOT_HOME=/opt/metabot bash install.sh`. Windows: `.\install.ps1 -Dir C:\opt\metabot`.
+
 ---
 
 ## Multi-Engine: Claude Code, Kimi Code, and Codex CLI

--- a/bin/mb
+++ b/bin/mb
@@ -4,9 +4,34 @@
 
 set -euo pipefail
 
-# --- Config: always read .env, then fall back to env vars / defaults ---
-METABOT_ENV="${METABOT_HOME:-$HOME/metabot}/.env"
-if [[ -f "$METABOT_ENV" ]]; then
+# --- Config: env vars > .env file > defaults ---
+# Locate .env: METABOT_HOME > script's parent dir (handles symlinks via readlink) > $HOME/metabot
+_find_env() {
+  if [[ -n "${METABOT_HOME:-}" && -f "$METABOT_HOME/.env" ]]; then
+    echo "$METABOT_HOME/.env"
+    return
+  fi
+  # Resolve symlinks so a symlinked install still finds its sibling .env
+  local src="${BASH_SOURCE[0]}"
+  if command -v readlink &>/dev/null; then
+    src="$(readlink -f "$src" 2>/dev/null || echo "$src")"
+  fi
+  local sd
+  sd="$(cd "$(dirname "$src")/.." 2>/dev/null && pwd)" || sd=""
+  if [[ -n "$sd" && -f "$sd/.env" ]]; then
+    METABOT_HOME="$sd"
+    echo "$sd/.env"
+    return
+  fi
+  if [[ -f "$HOME/metabot/.env" ]]; then
+    METABOT_HOME="$HOME/metabot"
+    echo "$HOME/metabot/.env"
+    return
+  fi
+  echo ""
+}
+METABOT_ENV="$(_find_env)"
+if [[ -n "$METABOT_ENV" && -f "$METABOT_ENV" ]]; then
   _port=$(sed -n 's/^API_PORT=//p' "$METABOT_ENV" 2>/dev/null || true)
   _secret=$(sed -n 's/^API_SECRET=//p' "$METABOT_ENV" 2>/dev/null || true)
   _url=$(sed -n 's/^METABOT_URL=//p' "$METABOT_ENV" 2>/dev/null || true)

--- a/bin/metabot
+++ b/bin/metabot
@@ -4,7 +4,19 @@
 
 set -euo pipefail
 
-METABOT_HOME="${METABOT_HOME:-$HOME/metabot}"
+# Resolve METABOT_HOME: env var > script's parent dir (follows symlinks) > $HOME/metabot
+if [[ -z "${METABOT_HOME:-}" ]]; then
+  _src="${BASH_SOURCE[0]}"
+  if command -v readlink &>/dev/null; then
+    _src="$(readlink -f "$_src" 2>/dev/null || echo "$_src")"
+  fi
+  _sd="$(cd "$(dirname "$_src")/.." 2>/dev/null && pwd)" || _sd=""
+  if [[ -n "$_sd" && -d "$_sd/.git" && -f "$_sd/package.json" ]]; then
+    METABOT_HOME="$_sd"
+  else
+    METABOT_HOME="$HOME/metabot"
+  fi
+fi
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/docs/troubleshooting.en.md
+++ b/docs/troubleshooting.en.md
@@ -2,9 +2,11 @@
 
 ## "Error: Claude Code process exited with code 1"
 
-The bot starts but replies with this error when you message it.
+The bot starts but replies with this error when you message it. There are two distinct causes:
 
-**Cause:** Claude CLI is not authenticated. The SDK spawns `claude` as a child process — if it has no valid credentials, it exits immediately with code 1.
+### Cause A: Claude CLI not authenticated
+
+The SDK spawns `claude` as a child process — if it has no valid credentials, it exits immediately with code 1.
 
 **Fix** (run in a **separate terminal**, not inside Claude Code):
 
@@ -25,6 +27,24 @@ metabot restart
 
 !!! warning
     You cannot run `claude login` or `claude auth status` from inside a Claude Code session (nested sessions are blocked). Always use a separate terminal.
+
+### Cause B: Running as root/sudo
+
+Claude Code refuses to run `--dangerously-skip-permissions` under root privileges — the subprocess exits with code 1 immediately, even if authentication is valid. This is common when metabot runs as the `root` user (e.g. on a VPS or inside a Docker container with the default root user).
+
+You can confirm this is the cause by checking `pm2 logs metabot` for:
+
+```
+--dangerously-skip-permissions cannot be used with root/sudo privileges
+```
+
+**Fix:** This is handled automatically since [this fix](https://github.com/xvirobotics/metabot/pull/213). When metabot detects it is running as root, it switches to `permissionMode: auto` (which auto-approves all tool permissions without requiring `--dangerously-skip-permissions`). Make sure you are on a version that includes this fix, then restart:
+
+```bash
+git pull && npm run build && metabot restart
+```
+
+If you prefer a more permanent solution, run metabot as a non-root user.
 
 ## Service Won't Connect to Feishu
 

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -5,7 +5,13 @@ module.exports = {
     {
       name: 'metabot',
       script: 'src/index.ts',
-      interpreter: path.join(__dirname, 'node_modules/.bin/tsx'),
+      // Use `node --import tsx` instead of the tsx wrapper script.
+      // The wrapper in node_modules/.bin/tsx is a POSIX shell script with no
+      // .cmd shim, so PM2's child_process.spawn can't exec it on Windows
+      // (EINVAL). `node --import tsx` is tsx 4.x's documented cross-platform
+      // entrypoint and works identically on Linux/macOS/Windows.
+      interpreter: 'node',
+      interpreter_args: '--import tsx',
       cwd: __dirname,
 
       // Watch disabled — use `metabot restart` to apply code changes manually

--- a/install.ps1
+++ b/install.ps1
@@ -287,7 +287,20 @@ if (Test-Path (Join-Path $MetabotHome ".git")) {
     Write-Info "Existing installation found, pulling latest..."
     Push-Location $MetabotHome
     $OldHead = git rev-parse HEAD
-    try { git pull --ff-only } catch { Write-Warn "git pull failed, continuing with existing code" }
+    git pull --ff-only
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Err "git pull --ff-only failed at $MetabotHome."
+        Write-Err "Your checkout has diverged from origin or has uncommitted changes."
+        Write-Err "Continuing with stale code would silently break later phases (e.g. Phase 6 'skill not found')."
+        Write-Err ""
+        Write-Err "Fix one of these and re-run install.ps1:"
+        Write-Err "  - Inspect: cd $MetabotHome; git status; git log --oneline -5"
+        Write-Err "  - Stash & retry:    cd $MetabotHome; git stash; git pull --ff-only"
+        Write-Err "  - Reset to origin (DESTROYS local commits/edits):"
+        Write-Err "      cd $MetabotHome; git fetch origin; git reset --hard origin/main"
+        exit 1
+    }
     $NewHead = git rev-parse HEAD
 
     # Re-exec with updated install.ps1 if it changed
@@ -567,6 +580,18 @@ Write-Step "Phase 6: Installing skills and setting up workspace"
 
 $SkillsDir = Join-Path $env:USERPROFILE ".claude\skills"
 New-Item -ItemType Directory -Path $SkillsDir -Force | Out-Null
+
+# Sanity check: the bundled skill tree must exist in the checked-out repo.
+# If it's missing, the user's checkout is stale (predates the skill bundling
+# commits) — fail with a clear message instead of cryptic Copy-Item errors.
+$SkillSentinel = Join-Path $MetabotHome "src\skills\metaskill\SKILL.md"
+if (-not (Test-Path $SkillSentinel)) {
+    Write-Err "Bundled skill source not found at: $SkillSentinel"
+    Write-Err "Your $MetabotHome checkout appears to be stale or incomplete."
+    Write-Err "Try: cd $MetabotHome; git fetch origin; git reset --hard origin/main"
+    Write-Err "(WARNING: 'git reset --hard' discards uncommitted local changes.)"
+    exit 1
+}
 
 # Install metaskill
 Write-Info "Installing metaskill skill..."

--- a/install.ps1
+++ b/install.ps1
@@ -1,14 +1,49 @@
 # MetaBot Installer for Windows PowerShell
-# Usage: irm https://raw.githubusercontent.com/Shiien/metabot/main/install.ps1 | iex
+# Usage:
+#   irm https://raw.githubusercontent.com/Shiien/metabot/main/install.ps1 | iex
+#   .\install.ps1 -Dir C:\opt\metabot
+#   $env:METABOT_HOME = "C:\opt\metabot"; irm <url> | iex
 #Requires -Version 5.1
 
+[CmdletBinding()]
+param(
+    [Alias('d', 'InstallDir')]
+    [string]$Dir = "",
+
+    [switch]$Help
+)
+
 $ErrorActionPreference = "Stop"
+
+if ($Help) {
+    @"
+MetaBot Installer (Windows)
+
+Usage:
+  .\install.ps1 [-Dir <path>]
+  irm <url> | iex                        # uses default ($env:USERPROFILE\metabot) or $env:METABOT_HOME
+
+Parameters:
+  -Dir, -d <path>     Install MetaBot to <path>.
+                      Priority: -Dir > `$env:METABOT_HOME > interactive prompt.
+                      Default: `$env:USERPROFILE\metabot
+  -Help               Show this help and exit.
+
+Examples:
+  .\install.ps1
+  .\install.ps1 -Dir C:\opt\metabot
+  `$env:METABOT_HOME = "C:\opt\metabot"; irm <url> | iex
+"@ | Write-Host
+    exit 0
+}
 
 # ============================================================================
 # Configuration defaults
 # ============================================================================
 $MetabotRepo = if ($env:METABOT_REPO) { $env:METABOT_REPO } else { "https://github.com/Shiien/metabot.git" }
-$MetabotHome = if ($env:METABOT_HOME) { $env:METABOT_HOME } else { Join-Path $env:USERPROFILE "metabot" }
+# $MetabotHome is resolved later (Phase 0.5) — priority: -Dir > env > prompt > default.
+$DefaultMetabotHome = Join-Path $env:USERPROFILE "metabot"
+$MetabotHome = $null
 
 # ============================================================================
 # Helper functions (colors via Write-Host -ForegroundColor)
@@ -103,6 +138,51 @@ if ($PSVer.Major -lt 5 -or ($PSVer.Major -eq 5 -and $PSVer.Minor -lt 1)) {
     Write-Err "PowerShell 5.1+ is required. Current: $PSVer"
     exit 1
 }
+
+# ============================================================================
+# Phase 0.5: Resolve install directory
+# Priority: -Dir parameter > $env:METABOT_HOME > interactive prompt > default.
+# ============================================================================
+Write-Step "Phase 0.5: Choose install directory"
+
+if ($Dir) {
+    $MetabotHome = $Dir
+    Write-Info "Using install directory from -Dir: $MetabotHome"
+} elseif ($env:METABOT_HOME) {
+    $MetabotHome = $env:METABOT_HOME
+    Write-Info "Using install directory from `$env:METABOT_HOME: $MetabotHome"
+} else {
+    Write-Host ""
+    Write-Host "Where should MetaBot be installed?" -ForegroundColor White
+    Write-Host "  (Override later with -Dir or `$env:METABOT_HOME.)"
+    $MetabotHome = Read-Input "Install directory" $DefaultMetabotHome
+}
+
+# Expand a leading ~ to $env:USERPROFILE.
+if ($MetabotHome.StartsWith("~")) {
+    $MetabotHome = Join-Path $env:USERPROFILE ($MetabotHome.Substring(1).TrimStart('\','/'))
+}
+
+# Require a rooted path so all later $MetabotHome references are unambiguous.
+if (-not [System.IO.Path]::IsPathRooted($MetabotHome)) {
+    Write-Err "Install path must be absolute, got: $MetabotHome"
+    exit 1
+}
+
+# Refuse a few obviously-bad targets that would clobber the user's profile or a system root.
+$normalized = $MetabotHome.TrimEnd('\','/')
+$forbidden = @(
+    $env:USERPROFILE.TrimEnd('\','/'),
+    $env:SystemDrive,                          # e.g. "C:"
+    (Join-Path $env:SystemDrive 'Users').TrimEnd('\','/'),
+    (Join-Path $env:SystemDrive 'Windows').TrimEnd('\','/')
+) | ForEach-Object { $_.TrimEnd('\','/') }
+if ($forbidden -contains $normalized -or $normalized -eq '') {
+    Write-Err "Refusing to install directly into $MetabotHome — pick a dedicated subdirectory."
+    exit 1
+}
+
+Write-Success "Install directory: $MetabotHome"
 
 # ============================================================================
 # Phase 1: Check prerequisites
@@ -631,6 +711,15 @@ if ($HasBash) {
 } else {
     Write-Warn "Git Bash not found. CLI tools (mm, mb, metabot) require bash."
     Write-Warn "Install Git for Windows (https://git-scm.com) to enable CLI tools."
+}
+
+# Persist METABOT_HOME for non-default install paths so the CLI tools
+# (mm/mb/metabot) can find the install in new shell sessions. The CLIs all
+# fall back to ~/metabot, so we only need to persist when it differs.
+if ($MetabotHome -ne $DefaultMetabotHome) {
+    [System.Environment]::SetEnvironmentVariable("METABOT_HOME", $MetabotHome, "User")
+    $env:METABOT_HOME = $MetabotHome
+    Write-Info "Persisted METABOT_HOME=$MetabotHome to user environment"
 }
 
 # ============================================================================

--- a/install.sh
+++ b/install.sh
@@ -329,7 +329,18 @@ if [[ -d "$METABOT_HOME/.git" ]]; then
   info "Existing installation found, pulling latest..."
   cd "$METABOT_HOME"
   OLD_HEAD="$(git rev-parse HEAD)"
-  git pull --ff-only || warn "git pull failed, continuing with existing code"
+  if ! git pull --ff-only; then
+    error "git pull --ff-only failed at $METABOT_HOME."
+    error "Your checkout has diverged from origin or has uncommitted changes."
+    error "Continuing with stale code would silently break later phases (e.g. Phase 6 'skill not found')."
+    error ""
+    error "Fix one of these and re-run install.sh:"
+    error "  - Inspect:        cd $METABOT_HOME && git status && git log --oneline -5"
+    error "  - Stash & retry:  cd $METABOT_HOME && git stash && git pull --ff-only"
+    error "  - Reset to origin (DESTROYS local commits/edits):"
+    error "      cd $METABOT_HOME && git fetch origin && git reset --hard origin/main"
+    exit 1
+  fi
   NEW_HEAD="$(git rev-parse HEAD)"
   # Re-exec with the updated install.sh if it changed (avoids running stale code from memory)
   if [[ "$OLD_HEAD" != "$NEW_HEAD" && -z "${METABOT_REEXEC:-}" ]]; then
@@ -744,6 +755,18 @@ step "Phase 6: Installing skills and setting up workspace"
 
 SKILLS_DIR="$HOME/.claude/skills"
 mkdir -p "$SKILLS_DIR"
+
+# Sanity check: bundled skill tree must exist in the checked-out repo.
+# If it's missing, the user's checkout is stale (predates the skill bundling
+# commits) — fail with a clear message instead of cryptic cp errors.
+SKILL_SENTINEL="$METABOT_HOME/src/skills/metaskill/SKILL.md"
+if [[ ! -f "$SKILL_SENTINEL" ]]; then
+  error "Bundled skill source not found at: $SKILL_SENTINEL"
+  error "Your $METABOT_HOME checkout appears to be stale or incomplete."
+  error "Try: cd $METABOT_HOME && git fetch origin && git reset --hard origin/main"
+  error "(WARNING: 'git reset --hard' discards uncommitted local changes.)"
+  exit 1
+fi
 
 # Install metaskill (bundled in src/skills/metaskill/)
 info "Installing metaskill skill..."

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # MetaBot Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/Liyunlun/metabot/main/install.sh | bash
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Liyunlun/metabot/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Liyunlun/metabot/main/install.sh | bash -s -- --dir /opt/metabot
+#   METABOT_HOME=/opt/metabot bash install.sh
 set -euo pipefail
 
 # ============================================================================
@@ -14,9 +17,58 @@ else
 fi
 
 # ============================================================================
+# Parse CLI arguments
+# ============================================================================
+INSTALL_DIR_ARG=""
+print_usage() {
+  cat <<'USAGE'
+MetaBot Installer
+
+Usage:
+  bash install.sh [OPTIONS]
+  curl -fsSL <url> | bash -s -- [OPTIONS]
+
+Options:
+  -d, --dir <path>     Install MetaBot to <path>.
+                       Priority: --dir > METABOT_HOME env var > interactive prompt.
+                       Default: $HOME/metabot
+  -h, --help           Show this help and exit.
+
+Examples:
+  bash install.sh
+  bash install.sh --dir /opt/metabot
+  bash install.sh -d ~/projects/metabot
+  METABOT_HOME=/opt/metabot bash install.sh
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--dir)
+      [[ $# -ge 2 ]] || { echo "Error: $1 requires a path argument" >&2; exit 1; }
+      INSTALL_DIR_ARG="$2"
+      shift 2
+      ;;
+    --dir=*)
+      INSTALL_DIR_ARG="${1#--dir=}"
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Warning: unknown argument '$1'" >&2
+      shift
+      ;;
+  esac
+done
+
+# ============================================================================
 # Configuration defaults
 # ============================================================================
-METABOT_HOME="${METABOT_HOME:-$HOME/metabot}"
+# METABOT_HOME is resolved later (Phase 0.5) — priority: --dir > env var > prompt > default.
+DEFAULT_METABOT_HOME="$HOME/metabot"
 METABOT_REPO="${METABOT_REPO:-https://github.com/Liyunlun/metabot.git}"
 
 # ============================================================================
@@ -130,6 +182,43 @@ sed_i() {
     sed -i "$@"
   fi
 }
+
+# ============================================================================
+# Phase 0.5: Resolve install directory
+# Priority: --dir CLI arg > METABOT_HOME env var > interactive prompt > default.
+# ============================================================================
+step "Phase 0.5: Choose install directory"
+
+if [[ -n "$INSTALL_DIR_ARG" ]]; then
+  METABOT_HOME="$INSTALL_DIR_ARG"
+  info "Using install directory from --dir: $METABOT_HOME"
+elif [[ -n "${METABOT_HOME:-}" ]]; then
+  info "Using install directory from METABOT_HOME env: $METABOT_HOME"
+else
+  echo ""
+  echo -e "${BOLD}Where should MetaBot be installed?${NC}"
+  echo "  (You can override later with the METABOT_HOME env var or --dir flag.)"
+  prompt_input METABOT_HOME "Install directory" "$DEFAULT_METABOT_HOME"
+fi
+
+# Expand a leading ~ to $HOME (avoids eval; safe with spaces).
+METABOT_HOME="${METABOT_HOME/#\~/$HOME}"
+
+# Require an absolute path so all later $METABOT_HOME references are unambiguous.
+if [[ "$METABOT_HOME" != /* ]]; then
+  error "Install path must be absolute, got: $METABOT_HOME"
+  exit 1
+fi
+
+# Refuse a few obviously-bad targets that would clobber the user's home or root.
+case "$METABOT_HOME" in
+  /|/root|/home|/Users|"$HOME")
+    error "Refusing to install directly into $METABOT_HOME — pick a dedicated subdirectory."
+    exit 1
+    ;;
+esac
+
+success "Install directory: $METABOT_HOME"
 
 # ============================================================================
 # Phase 1: Check prerequisites
@@ -1031,6 +1120,24 @@ if ! echo "$PATH" | grep -q "$LOCAL_BIN"; then
   info "Added ~/.local/bin to PATH in ~/.bashrc"
 fi
 success "mm/mb/metabot CLI tools installed to $LOCAL_BIN"
+
+# Persist METABOT_HOME for non-default install paths so the CLI tools
+# (mm/mb/metabot) can find the install in new shell sessions. The CLIs all
+# fall back to $HOME/metabot, so we only need to export when it differs.
+if [[ "$METABOT_HOME" != "$DEFAULT_METABOT_HOME" ]]; then
+  for rc_file in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+    [[ -f "$rc_file" ]] || continue
+    # Drop any prior export to keep this idempotent across re-runs.
+    if grep -q '^export METABOT_HOME=' "$rc_file" 2>/dev/null; then
+      sed_i '/^export METABOT_HOME=/d' "$rc_file"
+    fi
+  done
+  echo "export METABOT_HOME=\"$METABOT_HOME\"" >> "$HOME/.bashrc"
+  if [[ -f "$HOME/.zshrc" ]]; then
+    echo "export METABOT_HOME=\"$METABOT_HOME\"" >> "$HOME/.zshrc"
+  fi
+  info "Persisted METABOT_HOME=$METABOT_HOME to shell rc files"
+fi
 
 # ============================================================================
 # Phase 8: Build + Start MetaBot with PM2

--- a/src/engines/claude/executor.ts
+++ b/src/engines/claude/executor.ts
@@ -212,9 +212,10 @@ export class ClaudeExecutor {
   ) {}
 
   private buildQueryOptions(cwd: string, sessionId: string | undefined, abortController: AbortController, outputsDir?: string, apiContext?: ApiContext): Record<string, unknown> {
+    const isRoot = process.getuid?.() === 0;
     const queryOptions: Record<string, unknown> = {
-      permissionMode: 'bypassPermissions' as const,
-      allowDangerouslySkipPermissions: true,
+      permissionMode: isRoot ? 'auto' : ('bypassPermissions' as const),
+      ...(isRoot ? {} : { allowDangerouslySkipPermissions: true }),
       cwd,
       abortController,
       includePartialMessages: true,

--- a/src/engines/claude/session-manager.ts
+++ b/src/engines/claude/session-manager.ts
@@ -37,7 +37,13 @@ interface PersistedSession {
   engine?: EngineName;
 }
 
-const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Sessions never expire — user can /reset manually.
+// IMPORTANT: When switching a bot's defaultWorkingDirectory, do NOT delete
+// session files (~/.metabot/<bot>/sessions-*.json, sessions.db).
+// Old sessions must be preserved so the user can switch back to a previous
+// project and resume context. loadFromDisk() uses the new defaultWorkingDirectory
+// from config, not from the persisted session, so old sessions don't interfere.
+const SESSION_TTL_MS = Infinity;
 const MAX_SESSIONS = 10_000;
 
 export class SessionManager {

--- a/src/engines/claude/stream-processor.ts
+++ b/src/engines/claude/stream-processor.ts
@@ -1,5 +1,12 @@
 import type { SDKMessage } from './executor.js';
-import type { CardState, ToolCall, PendingQuestion, SubagentTask } from '../../feishu/card-builder.js';
+import type {
+  BackgroundEvent,
+  BackgroundTaskStatus,
+  CardState,
+  ToolCall,
+  PendingQuestion,
+  SubagentTask,
+} from '../../feishu/card-builder.js';
 
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.tiff']);
 
@@ -61,6 +68,8 @@ export class StreamProcessor {
   // Track per-API-call usage from stream events for accurate context window display
   private _lastInputTokens: number | undefined;
   private _lastOutputTokens: number | undefined;
+  // Live background tasks (Monitor, etc.) — task_id → latest rollup.
+  private _backgroundEvents: Map<string, BackgroundEvent> = new Map();
 
   constructor(
     private userPrompt: string,
@@ -78,6 +87,9 @@ export class StreamProcessor {
 
     switch (message.type) {
       case 'system':
+        // SDK emits task_started / task_progress / task_notification / task_updated
+        // as type='system' with a specific subtype. Surface them so Feishu can
+        // show background task (e.g. Monitor) progress mid-turn.
         this.processSystemMessage(message);
         break;
 
@@ -94,6 +106,11 @@ export class StreamProcessor {
 
       case 'stream_event':
         this.processStreamEvent(message);
+        break;
+
+      case 'task_notification':
+        // Codex translator synthesizes this shape for top-level error events.
+        this.recordCodexTaskNotification(message);
         break;
 
       case 'tool_use_summary':
@@ -147,7 +164,62 @@ export class StreamProcessor {
       sessionId: this.sessionId,
       workingDirectory: this.workingDirectory,
       numTurns: this.numTurns,
+      backgroundEvents: this._backgroundEvents.size > 0
+        ? [...this._backgroundEvents.values()]
+        : undefined,
     };
+  }
+
+  private recordTaskEvent(message: SDKMessage, subtype: string): void {
+    const m = message as Record<string, unknown>;
+    const taskId = typeof m.task_id === 'string' ? m.task_id : undefined;
+    if (!taskId) return;
+
+    // Ambient/housekeeping tasks (skip_transcript=true) stay hidden from the card.
+    if (m.skip_transcript === true) return;
+
+    const prior = this._backgroundEvents.get(taskId);
+    const patch = (m.patch as Record<string, unknown> | undefined) ?? undefined;
+    const description = typeof m.description === 'string'
+      ? m.description
+      : (typeof patch?.description === 'string' ? patch.description as string : prior?.description);
+
+    let status: BackgroundTaskStatus = prior?.status ?? 'running';
+    if (subtype === 'task_notification') {
+      const s = typeof m.status === 'string' ? m.status : undefined;
+      if (s === 'completed' || s === 'failed' || s === 'stopped') status = s;
+    } else if (subtype === 'task_updated') {
+      const s = typeof patch?.status === 'string' ? patch.status as string : undefined;
+      if (s === 'completed') status = 'completed';
+      else if (s === 'failed' || s === 'killed') status = 'failed';
+      else if (s === 'running') status = 'running';
+    }
+
+    // SDKTaskNotificationMessage.summary carries the last-line event text for Monitor
+    // and the final message for one-shot background tasks. SDKTaskProgressMessage
+    // also exposes an optional summary for in-flight updates.
+    const summary = typeof m.summary === 'string' ? m.summary : undefined;
+    const lastEvent = summary ?? prior?.lastEvent;
+
+    this._backgroundEvents.set(taskId, {
+      taskId,
+      description: description ?? prior?.description ?? 'background task',
+      status,
+      lastEvent,
+    });
+  }
+
+  private recordCodexTaskNotification(message: SDKMessage): void {
+    const m = message as Record<string, unknown>;
+    const result = typeof m.result === 'string' ? m.result : undefined;
+    if (!result) return;
+    const taskId = typeof m.session_id === 'string' ? m.session_id : 'codex';
+    this._backgroundEvents.set(taskId, {
+      taskId,
+      description: 'Codex notification',
+      status: 'running',
+      lastEvent: result,
+    });
   }
 
   private processAssistantMessage(message: SDKMessage): void {
@@ -305,6 +377,17 @@ export class StreamProcessor {
   private processSystemMessage(message: SDKMessage): void {
     if (!message.subtype) return;
 
+    // Surface background task events (Monitor, etc.) regardless of whether they
+    // also represent a subagent. recordTaskEvent filters skip_transcript=true.
+    if (
+      message.subtype === 'task_started'
+      || message.subtype === 'task_progress'
+      || message.subtype === 'task_notification'
+      || message.subtype === 'task_updated'
+    ) {
+      this.recordTaskEvent(message, message.subtype);
+    }
+
     switch (message.subtype) {
       case 'task_started':
         if (message.task_id) {
@@ -443,6 +526,9 @@ export class StreamProcessor {
       numTurns: this.numTurns,
       totalTokens: this._totalTokens,
       contextWindow: this._contextWindow,
+      backgroundEvents: this._backgroundEvents.size > 0
+        ? [...this._backgroundEvents.values()]
+        : undefined,
     };
   }
 
@@ -555,6 +641,9 @@ export class StreamProcessor {
       sessionId: this.sessionId,
       workingDirectory: this.workingDirectory,
       numTurns: this.numTurns,
+      backgroundEvents: this._backgroundEvents.size > 0
+        ? [...this._backgroundEvents.values()]
+        : undefined,
     };
   }
 

--- a/src/feishu/card-builder.ts
+++ b/src/feishu/card-builder.ts
@@ -1,5 +1,13 @@
 // Re-export shared types so existing imports from this module continue to work
-export type { CardStatus, ToolCall, PendingQuestion, CardState, SubagentTask } from '../types.js';
+export type {
+  CardStatus,
+  ToolCall,
+  PendingQuestion,
+  CardState,
+  SubagentTask,
+  BackgroundEvent,
+  BackgroundTaskStatus,
+} from '../types.js';
 import type { CardState, CardStatus } from '../types.js';
 
 const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: string }> = {
@@ -11,6 +19,18 @@ const STATUS_CONFIG: Record<CardStatus, { color: string; title: string; icon: st
 };
 
 export const MAX_CONTENT_LENGTH = 28000;
+
+const BG_ICON: Record<'running' | 'completed' | 'failed' | 'stopped', string> = {
+  running: '⏳',
+  completed: '✅',
+  failed: '❌',
+  stopped: '⏹️',
+};
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + '…';
+}
 
 /**
  * Split long text into chunks that each fit within MAX_CONTENT_LENGTH.
@@ -315,6 +335,21 @@ export function buildCard(state: CardState): string {
           content: sanitizeLarkMd(detailLines.join('\n\n')),
         },
       ],
+    });
+  }
+
+  // Background tasks (Monitor, etc.) — show live stdout events / final status
+  if (state.backgroundEvents && state.backgroundEvents.length > 0) {
+    const lines = state.backgroundEvents.map((ev) => {
+      const icon = BG_ICON[ev.status];
+      const shortId = ev.taskId.slice(0, 6);
+      const desc = truncate(ev.description, 60);
+      const last = ev.lastEvent ? ` — _${truncate(ev.lastEvent, 140)}_` : '';
+      return `${icon} **${desc}** \`${shortId}\`${last}`;
+    });
+    elements.push({
+      tag: 'markdown',
+      content: '📡 **Background**\n' + lines.join('\n'),
     });
   }
 

--- a/src/feishu/event-handler.ts
+++ b/src/feishu/event-handler.ts
@@ -149,9 +149,9 @@ export function createEventDispatcher(
         // Exceptions: 2-member groups are treated like DMs; groupNoMention mode skips @mention check
         const mentions = message.mentions;
         if (chatType === 'group') {
-          const botMentioned = mentions?.some(
-            (m: any) => !botOpenId || m.id?.open_id === botOpenId,
-          );
+          const botMentioned = botOpenId
+            ? mentions?.some((m: any) => m.id?.open_id === botOpenId)
+            : mentions && mentions.length > 0;
           if (!botMentioned) {
             // groupNoMention mode: respond to all messages without @mention
             if (config.groupNoMention) {

--- a/src/feishu/message-sender.ts
+++ b/src/feishu/message-sender.ts
@@ -139,7 +139,7 @@ export class MessageSender {
     }
   }
 
-  async sendImage(chatId: string, imageKey: string): Promise<void> {
+  async sendImage(chatId: string, imageKey: string): Promise<boolean> {
     try {
       await this.client.im.v1.message.create({
         params: { receive_id_type: 'chat_id' },
@@ -149,16 +149,17 @@ export class MessageSender {
           msg_type: 'image',
         },
       });
+      return true;
     } catch (err) {
       this.logger.error({ err, chatId, imageKey }, 'Failed to send image');
+      return false;
     }
   }
 
   async sendImageFile(chatId: string, filePath: string): Promise<boolean> {
     const imageKey = await this.uploadImage(filePath);
     if (!imageKey) return false;
-    await this.sendImage(chatId, imageKey);
-    return true;
+    return this.sendImage(chatId, imageKey);
   }
 
   async uploadFile(filePath: string, fileName: string, fileType: string): Promise<string | undefined> {
@@ -181,7 +182,7 @@ export class MessageSender {
     }
   }
 
-  async sendFile(chatId: string, fileKey: string): Promise<void> {
+  async sendFile(chatId: string, fileKey: string): Promise<boolean> {
     try {
       await this.client.im.v1.message.create({
         params: { receive_id_type: 'chat_id' },
@@ -191,16 +192,17 @@ export class MessageSender {
           msg_type: 'file',
         },
       });
+      return true;
     } catch (err) {
       this.logger.error({ err, chatId, fileKey }, 'Failed to send file');
+      return false;
     }
   }
 
   async sendLocalFile(chatId: string, filePath: string, fileName: string, fileType: string): Promise<boolean> {
     const fileKey = await this.uploadFile(filePath, fileName, fileType);
     if (!fileKey) return false;
-    await this.sendFile(chatId, fileKey);
-    return true;
+    return this.sendFile(chatId, fileKey);
   }
 
   async getChatMemberCount(chatId: string): Promise<number | undefined> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,16 @@ export interface SubagentTask {
   toolCalls?: ToolCall[];
 }
 
+export type BackgroundTaskStatus = 'running' | 'completed' | 'failed' | 'stopped';
+
+export interface BackgroundEvent {
+  taskId: string;
+  description: string;
+  status: BackgroundTaskStatus;
+  /** Latest stdout event line from the task, if any. */
+  lastEvent?: string;
+}
+
 export interface CardState {
   status: CardStatus;
   userPrompt: string;
@@ -74,6 +84,8 @@ export interface CardState {
   cardTitle?: string;
   /** Cumulative session cost (USD), accumulated across queries until /reset */
   sessionCostUsd?: number;
+  /** Background tasks (e.g. Monitor) the agent has spawned during this turn. */
+  backgroundEvents?: BackgroundEvent[];
 }
 
 export interface IncomingMessage {

--- a/tests/card-builder.test.ts
+++ b/tests/card-builder.test.ts
@@ -195,6 +195,40 @@ describe('buildCard', () => {
     const md = json.elements.find((e: any) => e.tag === 'markdown' && /thinking/i.test(e.content));
     expect(md).toBeDefined();
   });
+
+  it('renders a background task section with status icon + last event', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'watch ci',
+      responseText: 'watching…',
+      toolCalls: [],
+      backgroundEvents: [
+        { taskId: 'bheol4172', description: 'Watching CI for PR #215', status: 'running', lastEvent: 'check (20) running' },
+        { taskId: 'bmkr16j6f', description: 'Watching deploy', status: 'completed', lastEvent: 'CI done: success' },
+      ],
+    };
+    const json = JSON.parse(buildCard(state));
+    const bg = json.elements.find((e: any) => e.tag === 'markdown' && /Background/.test(e.content));
+    expect(bg).toBeDefined();
+    expect(bg.content).toContain('⏳');
+    expect(bg.content).toContain('✅');
+    expect(bg.content).toContain('Watching CI for PR #215');
+    expect(bg.content).toContain('check (20) running');
+    expect(bg.content).toContain('CI done: success');
+    expect(bg.content).toContain('bheol4'); // short task id
+  });
+
+  it('omits background section when no events', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'x',
+      responseText: 'y',
+      toolCalls: [],
+    };
+    const json = JSON.parse(buildCard(state));
+    const bg = json.elements.find((e: any) => e.tag === 'markdown' && /Background/.test(e.content));
+    expect(bg).toBeUndefined();
+  });
 });
 
 describe('buildHelpCard', () => {

--- a/tests/stream-processor.test.ts
+++ b/tests/stream-processor.test.ts
@@ -368,6 +368,116 @@ describe('StreamProcessor', () => {
   });
 });
 
+describe('StreamProcessor background task events', () => {
+  it('surfaces task_started as a running background event', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'system',
+      subtype: 'task_started',
+      task_id: 't-1',
+      description: 'Watching CI for PR #215',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents).toEqual([
+      { taskId: 't-1', description: 'Watching CI for PR #215', status: 'running', lastEvent: undefined },
+    ]);
+  });
+
+  it('updates description + lastEvent on task_progress', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 't-1', description: 'Watching CI',
+    } as unknown as SDKMessage));
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_progress', task_id: 't-1',
+      description: 'Watching CI', summary: 'check (20) running',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0]).toEqual({
+      taskId: 't-1', description: 'Watching CI', status: 'running', lastEvent: 'check (20) running',
+    });
+  });
+
+  it('marks a task completed with its final summary on task_notification', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 't-1', description: 'Watch build',
+    } as unknown as SDKMessage));
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-1',
+      status: 'completed', summary: 'CI done: success',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0]).toMatchObject({
+      taskId: 't-1', status: 'completed', lastEvent: 'CI done: success',
+    });
+  });
+
+  it('picks up failed / stopped statuses from task_notification', () => {
+    const p = new StreamProcessor('hi');
+    const failed = p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-fail',
+      status: 'failed', summary: 'crashed',
+    } as unknown as SDKMessage));
+    expect(failed.backgroundEvents?.[0].status).toBe('failed');
+
+    const stopped = p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-stop',
+      status: 'stopped',
+    } as unknown as SDKMessage));
+    expect(stopped.backgroundEvents?.find(e => e.taskId === 't-stop')?.status).toBe('stopped');
+  });
+
+  it('applies status patches from task_updated', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 't-1', description: 'Watch build',
+    } as unknown as SDKMessage));
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_updated', task_id: 't-1',
+      patch: { status: 'killed' },
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0].status).toBe('failed');
+  });
+
+  it('hides ambient / skip_transcript tasks from the card', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_started', task_id: 'housekeeping',
+      description: 'Ambient thing', skip_transcript: true,
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents).toBeUndefined();
+  });
+
+  it('ignores task events without a task_id', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'system', subtype: 'task_started', description: 'no id',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents).toBeUndefined();
+  });
+
+  it('renders Codex translator task_notification events too', () => {
+    const p = new StreamProcessor('hi');
+    const state = p.processMessage(msg({
+      type: 'task_notification', session_id: 'codex-sess', result: 'rate limited',
+    } as unknown as SDKMessage));
+    expect(state.backgroundEvents?.[0]).toMatchObject({
+      taskId: 'codex-sess', lastEvent: 'rate limited',
+    });
+  });
+
+  it('propagates backgroundEvents through the result message', () => {
+    const p = new StreamProcessor('hi');
+    p.processMessage(msg({
+      type: 'system', subtype: 'task_notification', task_id: 't-1',
+      status: 'completed', summary: 'done',
+    } as unknown as SDKMessage));
+    const result = p.processMessage(msg({
+      type: 'result', subtype: 'success', result: 'all set', total_cost_usd: 0, duration_ms: 10,
+    }));
+    expect(result.status).toBe('complete');
+    expect(result.backgroundEvents?.[0]).toMatchObject({ taskId: 't-1', status: 'completed' });
+  });
+});
+
 describe('extractImagePaths', () => {
   it('extracts image paths from text', () => {
     const text = 'Created file at /tmp/img/chart.png and /home/user/photo.jpg';


### PR DESCRIPTION
## Summary

Final Batch 5 of upstream catch-up. Cherry-picks 9 small upstream PRs covering bug fixes, installer DX, and infrastructure tweaks.

### Included upstream PRs
- #212 fix(executor): switch to auto permission mode when running as root
- #213 fix(feishu): propagate send/update failures so retry + fallback actually trigger
- #217 feat(feishu): surface Monitor / background task events on the live card
- #220 feat(installer): allow custom install directory via --dir / -Dir flag
- #225 fix(feishu): require explicit @mention match when botOpenId is known
- #245 fix(ecosystem): use 'node --import tsx' for cross-platform PM2 spawn
- #242 feat(session): disable session TTL (sessions never expire)
- #246 fix(install): fail fast on git pull error and stale checkout
- #247 fix(cli): auto-detect METABOT_HOME from script's own location

### Notable conflict resolutions
- **#213**: kept HEAD's failure-handling (mark final-sent only on success, V2/raw card support).
- **#217**: merged two processSystemMessage methods; route task_* events through both subagent + background maps.
- **#220 / #247**: kept fork's repo URLs while taking upstream's --dir / auto-detect logic.

## Test plan
- [x] npx tsc --noEmit clean
- [x] npx vitest run — 707/707 green

Closes #37