### PR TITLE
fix: restore footer fields + elapsed timer in Card Schema 2.0

### DIFF
--- a/src/feishu/card-builder-v2.ts
+++ b/src/feishu/card-builder-v2.ts
@@ -42,6 +42,14 @@ function truncate(text: string, max: number): string {
   return text.slice(0, max) + '…';
 }
 
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m${sec}s`;
+}
+
 function truncateContent(text: string): string {
   if (text.length <= MAX_CONTENT_LENGTH) return text;
   const half = Math.floor(MAX_CONTENT_LENGTH / 2) - 50;
@@ -117,6 +125,9 @@ export function buildCardV2(state: CardState): string {
   const config   = STATUS_CONFIG[state.status];
   const elements: unknown[] = [];
 
+  // Elapsed time for header / thinking placeholder
+  const elapsed = state.startTime ? formatElapsed(Date.now() - state.startTime) : undefined;
+
   // Tool calls section
   if (state.toolCalls.length > 0) {
     const toolLines = state.toolCalls.map((t) => {
@@ -159,7 +170,7 @@ export function buildCardV2(state: CardState): string {
   } else if (state.status === 'thinking') {
     elements.push({
       tag:     'markdown',
-      content: '_Thinking..._',
+      content: elapsed ? `_Thinking... (${elapsed})_` : '_Thinking..._',
     });
   }
 
@@ -209,9 +220,13 @@ export function buildCardV2(state: CardState): string {
     });
   }
 
-  // Stats footer — grey background panel
+  // Stats footer — grey background panel. Field order mirrors v1 card-builder
+  // so users see the same layout regardless of CARD_SCHEMA_V2.
   {
     const parts: string[] = [];
+    if (state.model) parts.push(state.model.replace(/^claude-/, ''));
+    if (state.thinking) parts.push(`thinking:${state.thinking}`);
+    if (state.effort) parts.push(`effort:${state.effort}`);
     if (state.totalTokens && state.contextWindow) {
       const pct    = Math.round((state.totalTokens / state.contextWindow) * 100);
       const tokensK = state.totalTokens >= 1000
@@ -223,8 +238,15 @@ export function buildCardV2(state: CardState): string {
     if (state.status === 'complete' || state.status === 'error') {
       if (state.sessionCostUsd != null) parts.push(`$${state.sessionCostUsd.toFixed(2)}`);
       if (state.model) parts.push(state.model.replace(/^claude-/, ''));
-      if (state.durationMs !== undefined) parts.push(`${(state.durationMs / 1000).toFixed(1)}s`);
     }
+    if (state.durationMs !== undefined) parts.push(`${(state.durationMs / 1000).toFixed(1)}s`);
+    if (state.numTurns !== undefined) parts.push(`${state.numTurns} turns`);
+    if (state.workingDirectory) {
+      const dir = state.workingDirectory;
+      const short = dir.length > 40 ? '.../' + dir.split('/').slice(-2).join('/') : dir;
+      parts.push(`📁 ${short}`);
+    }
+    if (state.sessionId) parts.push(`🔑 ${state.sessionId.slice(0, 8)}`);
     if (parts.length > 0) {
       elements.push({
         tag:               'column_set',
@@ -267,7 +289,11 @@ export function buildCardV2(state: CardState): string {
       template: config.color,
       title: {
         tag:     'plain_text',
-        content: `${config.icon} ${config.title}`,
+        content: state.cardTitle
+          ? `${config.icon} ${state.cardTitle}`
+          : elapsed && (state.status === 'thinking' || state.status === 'running')
+            ? `${config.icon} ${config.title} (${elapsed})`
+            : `${config.icon} ${config.title}`,
       },
     },
     body: {

--- a/tests/card-builder-v2.test.ts
+++ b/tests/card-builder-v2.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { buildCardV2 } from '../src/feishu/card-builder-v2.js';
+import type { CardState } from '../src/types.js';
+
+function findFooterContent(card: any): string {
+  const colSet = card.body.elements.find((e: any) => e.tag === 'column_set');
+  if (!colSet) return '';
+  return colSet.columns[0].elements[0].content as string;
+}
+
+describe('buildCardV2 header', () => {
+  it('renders elapsed time in title while running', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'task',
+      responseText: 'working',
+      toolCalls: [],
+      startTime: Date.now() - 5_000,
+    };
+    const json = JSON.parse(buildCardV2(state));
+    expect(json.header.title.content).toMatch(/Running\.\.\. \(\d+s\)/);
+  });
+
+  it('renders elapsed time in title while thinking', () => {
+    const state: CardState = {
+      status: 'thinking',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+      startTime: Date.now() - 12_000,
+    };
+    const json = JSON.parse(buildCardV2(state));
+    expect(json.header.title.content).toMatch(/Thinking\.\.\. \(\d+s\)/);
+  });
+
+  it('formats elapsed > 60s as MmSs', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'task',
+      responseText: 'working',
+      toolCalls: [],
+      startTime: Date.now() - 125_000,
+    };
+    const json = JSON.parse(buildCardV2(state));
+    expect(json.header.title.content).toMatch(/\(2m\d+s\)/);
+  });
+
+  it('does not render elapsed in title on complete', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'task',
+      responseText: 'done',
+      toolCalls: [],
+      startTime: Date.now() - 5_000,
+    };
+    const json = JSON.parse(buildCardV2(state));
+    expect(json.header.title.content).not.toMatch(/\(\d+s\)/);
+  });
+
+  it('overrides title with cardTitle when set', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+      cardTitle: 'Turn 1',
+    };
+    const json = JSON.parse(buildCardV2(state));
+    expect(json.header.title.content).toBe('🟢 Turn 1');
+  });
+
+  it('cardTitle takes precedence over elapsed', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+      startTime: Date.now() - 30_000,
+      cardTitle: '📊 Result',
+    };
+    const json = JSON.parse(buildCardV2(state));
+    expect(json.header.title.content).toBe('🔵 📊 Result');
+  });
+});
+
+describe('buildCardV2 thinking placeholder', () => {
+  it('shows elapsed suffix in thinking placeholder', () => {
+    const state: CardState = {
+      status: 'thinking',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+      startTime: Date.now() - 3_000,
+    };
+    const json = JSON.parse(buildCardV2(state));
+    const md = json.body.elements.find((e: any) => e.tag === 'markdown' && /Thinking/.test(e.content));
+    expect(md.content).toMatch(/_Thinking\.\.\. \(\d+s\)_/);
+  });
+
+  it('shows plain thinking placeholder when no startTime', () => {
+    const state: CardState = {
+      status: 'thinking',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+    };
+    const json = JSON.parse(buildCardV2(state));
+    const md = json.body.elements.find((e: any) => e.tag === 'markdown' && /Thinking/.test(e.content));
+    expect(md.content).toBe('_Thinking..._');
+  });
+});
+
+describe('buildCardV2 stats footer', () => {
+  it('renders all v1 footer fields on complete', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'task',
+      responseText: 'done',
+      toolCalls: [],
+      model: 'claude-opus-4-7',
+      thinking: 'adaptive',
+      effort: 'max',
+      totalTokens: 152700,
+      contextWindow: 200000,
+      sessionCostUsd: 38.58,
+      durationMs: 21000,
+      numTurns: 3,
+      workingDirectory: '/home/user/lyl/Research',
+      sessionId: '260a4c39-b47e-4534-88ca-bb4ac5b5b83a',
+    };
+    const json = JSON.parse(buildCardV2(state));
+    const content = findFooterContent(json);
+    expect(content).toContain('opus-4-7');
+    expect(content).toContain('thinking:adaptive');
+    expect(content).toContain('effort:max');
+    expect(content).toContain('ctx: 152.7k/200k (76%)');
+    expect(content).toContain('$38.58');
+    expect(content).toContain('21.0s');
+    expect(content).toContain('3 turns');
+    expect(content).toContain('📁');
+    expect(content).toContain('Research');
+    expect(content).toContain('🔑 260a4c39');
+  });
+
+  it('renders model + ctx during running', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'task',
+      responseText: 'working',
+      toolCalls: [],
+      model: 'claude-opus-4-7',
+      totalTokens: 1000,
+      contextWindow: 200000,
+    };
+    const json = JSON.parse(buildCardV2(state));
+    const content = findFooterContent(json);
+    expect(content).toContain('opus-4-7');
+    expect(content).toContain('ctx:');
+  });
+
+  it('does not render cost/duration during running', () => {
+    const state: CardState = {
+      status: 'running',
+      userPrompt: 'task',
+      responseText: 'working',
+      toolCalls: [],
+      sessionCostUsd: 1.23,
+    };
+    const json = JSON.parse(buildCardV2(state));
+    const content = findFooterContent(json);
+    expect(content).not.toContain('$1.23');
+  });
+
+  it('shortens long workingDirectory paths', () => {
+    const state: CardState = {
+      status: 'complete',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+      workingDirectory: '/very/long/path/to/some/deeply/nested/project/dir',
+    };
+    const json = JSON.parse(buildCardV2(state));
+    const content = findFooterContent(json);
+    expect(content).toMatch(/📁 \.\.\.\/project\/dir/);
+  });
+
+  it('omits footer entirely when no fields set', () => {
+    const state: CardState = {
+      status: 'thinking',
+      userPrompt: 'task',
+      responseText: '',
+      toolCalls: [],
+    };
+    const json = JSON.parse(buildCardV2(state));
+    const colSet = json.body.elements.find((e: any) => e.tag === 'column_set');
+    expect(colSet).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `formatElapsed(ms)` to `card-builder-v2.ts` and computes `elapsed` from `state.startTime`
- Header now shows `(Ns)` while `thinking`/`running`, plus honors `state.cardTitle` (used by frozen Turn cards)
- `_Thinking..._` placeholder gets the same `(Ns)` suffix
- Stats footer order matches v1: model · thinking · effort · ctx · `$cost` · model · duration · turns · 📁 cwd · 🔑 sessionId

## Why
Card Schema 2.0 became the default in Batch 2 but the port dropped fork-specific footer fields and the live elapsed counter. The user lost visibility into model/effort/cwd/sessionId and the running header stopped ticking.

Closes #39

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run tests/card-builder-v2.test.ts` — 13/13 new tests pass
- [x] `npx vitest run` — full suite 720/720 pass
- [ ] Manually confirm via Feishu after merge + restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)